### PR TITLE
Support for PHP 7 Custom Fields

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -266,8 +266,8 @@ function pmpromd_shortcode($atts, $content=null, $code="")
 									    if ( WP_DEBUG ) {
 									        error_log("Content of field data: " . print_r( $field, true));
                                         }
-
-										$meta_field = $auser->$field[1];
+                                        $field_val = $field[1];
+										$meta_field = $auser->$field_val;
 										if(!empty($meta_field))
 										{
 											?>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -305,8 +305,9 @@ function pmpromd_profile_shortcode($atts, $content=null, $code="")
 						foreach($fields_array as $field)
 						{
 							if(empty($field[0]))
-								break;							
-							$meta_field = $pu->$field[1];
+								break;
+							$field_val = $field[1];						
+							$meta_field = $pu->$field_val;
 							if(!empty($meta_field))
 							{
 								?>


### PR DESCRIPTION
This solves the issue on sites that use PHP 7 and try to show custom
fields by using `fields=“Label,metakey;”` and not showing up.

Tested on PHP 7.1 and 5.6