### PR TITLE
V.6.1 Commit

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Member Directory Add On
 Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-member-directory/
 Description: Adds a customizable Member Directory and Member Profiles to your membership site.
-Version:.6
+Version:.6.1
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: pmpro, paid memberships pro, members, directory
 Requires at least: 4
 Tested up to: 5.2.2
-Stable tag: .6
+Stable tag: .6.1
 
 Add a robust Member Directory and Profiles to Your Membership Site - with attributes to customize the display.
 
@@ -90,6 +90,11 @@ Please post it in the issues section of GitHub and we'll fix it as soon as we ca
 Please visit our premium support site at http://www.paidmembershipspro.com for more documentation and our support forums.
 
 == Changelog ==
+= .6.1 =
+* BUG FIX: Levels select in block not returning any results.
+* BUG FIX: Custom fields from Register Helper not working when multiple fields are set in the shortcode method.
+* BUG FIX: Remove "Levels" attribute from profile block method as profile shortcode does not support this attribute. Set the 'Require Membership' meta box to restrict access to profile pages.
+
 = .6 =
 * BUG FIX: Show default "Hide From Directory" if no directory page is set.
 * BUG FIX: Strip trailing semi-colon from "fields" attribute.


### PR DESCRIPTION
* BUG FIX: Levels select in block not returning any results.

* BUG FIX: Custom fields from Register Helper not working when multiple fields are set in the shortcode method.

* BUG FIX: Remove "Levels" attribute from profile block method as profile shortcode does not support this attribute. Set the 'Require Membership' meta box to restrict access to profile pages.