### PR TITLE
Allow filtering of template directory

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -11,7 +11,7 @@ Author URI: http://www.strangerstudios.com
 global $pmpromd_options;
 
 $path = dirname(__FILE__);
-$custom_dir = get_stylesheet_directory()."/paid-memberships-pro/pmpro-member-directory/";
+$custom_dir = apply_filters( 'pmpro_member_directory_templates_directory', get_stylesheet_directory()."/paid-memberships-pro/pmpro-member-directory/" );
 $custom_directory_file = $custom_dir."directory.php";
 $custom_profile_file = $custom_dir."profile.php";
 


### PR DESCRIPTION
Filtering the template directory allows templates to be included from anywhere, such as a plugin, instead of just the theme directory.

Example usage:

```
/**
 * Custom templates location from a plugin
 */
function filter_templates_directory( $dir ) {	

	return dirname( __FILE__ ) . '/templates/';
}

add_filter( 'pmpro_member_directory_templates_directory', 'filter_templates_directory', 10, 1 );
```