### PR TITLE
Version 0.7 improvements as documented in the changelog.

### DIFF
--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -39,6 +39,21 @@ div.pmpro_member_profile strong {display: block; }
     grid-template-columns: 1fr 1fr 1fr 1fr;
 }
 
+/* single directory item in list */
+.pmpro_member_directory .pmpro_member_directory-item,
+.pmpro_member_directory .pmpro_member_directory_row {
+    word-break: break-word;
+}
+.pmpro_member_directory_link {
+    word-break: normal;
+}
+
+/* single profile item */
+.pmpro_member_profile { }
+.pmpro_member_profile .pmpromd_filename {
+    display: block;
+}
+
 @media only screen and (max-width: 767px) {
     .pmpro_member_directory.pmpro_member_directory-2col,
     .pmpro_member_directory.pmpro_member_directory-3col,

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -1,12 +1,14 @@
 <?php
 /*
 Plugin Name: Paid Memberships Pro - Member Directory Add On
-Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-member-directory/
+Plugin URI: https://www.paidmembershipspro.com/add-ons/member-directory/
 Description: Adds a customizable Member Directory and Member Profiles to your membership site.
-Version:.6.1
-Author: Stranger Studios
-Author URI: http://www.strangerstudios.com
+Version: 0.7
+Author: Paid Memberships Pro
+Author URI: https://www.paidmembershipspro.com/
 */
+
+define( 'PMPRO_MEMBER_DIRECTORY_VERSION', '.7' );
 
 global $pmpromd_options;
 
@@ -91,7 +93,7 @@ function pmpromd_display_file_field($meta_field) {
 		case 'image/jpeg':
 		case 'image/png':
 		case 'image/gif':
-			return '<a href="' . $meta_field['fullurl'] . '" title="' . $meta_field['filename'] . '" target="_blank"><img class="subtype-' . $meta_field_file_type['ext'] . '" src="' . $meta_field['fullurl'] . '"><br />' . $meta_field['filename'] . '</a>'; break;
+			return '<a href="' . $meta_field['fullurl'] . '" title="' . $meta_field['filename'] . '" target="_blank"><img class="subtype-' . $meta_field_file_type['ext'] . '" src="' . $meta_field['fullurl'] . '"><span class="pmpromd_filename">' . $meta_field['filename'] . '</span></a>'; break;
 	case 'video/mpeg':
 	case 'video/mp4':
 		return do_shortcode('[video src="' . $meta_field['fullurl'] . '"]'); break;
@@ -99,7 +101,7 @@ function pmpromd_display_file_field($meta_field) {
 	case 'audio/wav':
 		return do_shortcode('[audio src="' . $meta_field['fullurl'] . '"]'); break;
 	default:
-		return '<a href="' . $meta_field['fullurl'] . '" title="' . $meta_field['filename'] . '" target="_blank"><img class="subtype-' . $meta_field_file_type['ext'] . '" src="' . wp_mime_type_icon($meta_field_file_type['type']) . '"><br />' . $meta_field['filename'] . '</a>'; break;
+		return '<a href="' . $meta_field['fullurl'] . '" title="' . $meta_field['filename'] . '" target="_blank"><img class="subtype-' . $meta_field_file_type['ext'] . '" src="' . wp_mime_type_icon($meta_field_file_type['type']) . '"><span class="pmpromd_filename">' . $meta_field['filename'] . '</span></a>'; break;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Please visit our premium support site at http://www.paidmembershipspro.com for m
 * SECURITY/ENHANCEMENT: Update NPM packages to latest version to resolve vulnerability issues.
 * BUG FIX: Stripping slashes when using an apostrophe in search field.
 * BUG FIX: Fixed notice and display bug when a trailing space was left in the shortcode's "fields" attribute.
+* BUG FIX: Added `method="post"` to search form on directory page to avoid errors where sites not using pretty permalinks would break.
 * BUG FIX/ENHANCEMENT: Replicated error_log for field data code in the "table" layout (logging was already in the other layouts).
 * BUG FIX/ENHANCEMENT: Added `word-break` css improvement for cases where a long name or email address was forcing overflow content.
 * BUG FIX/ENHANCEMENT: Fixed case where a user hidden from directory could still have their individual profile accessed through direct URL.

--- a/readme.txt
+++ b/readme.txt
@@ -2,14 +2,21 @@
 Contributors: strangerstudios
 Tags: pmpro, paid memberships pro, members, directory
 Requires at least: 4
-Tested up to: 5.2.2
-Stable tag: .6.1
+Tested up to: 5.4
+Stable tag: 0.7
 
 Add a robust Member Directory and Profiles to Your Membership Site - with attributes to customize the display.
 
 == Description ==
 The Member Directory Add On enhances your membership site with a public or private, searchable directory and member profiles.
 
+[Read the full documentation for the Member Directory and Profiles Add On](https://www.paidmembershipspro.com/add-ons/member-directory/)
+
+= Official Paid Memberships Pro Add On =
+
+This is an official Add On for [Paid Memberships Pro](https://www.paidmembershipspro.com), the most complete member management and membership subscriptions plugin for WordPress.
+
+= Shortcodes and Attributes =
 This plugin creates 2 shortcodes for a Member Directory and Member Profile pages, which can be defined in Memberships > Page Settings of the WordPress admin.
 
 Shortcode attributes for `[pmpro_member_directory]` include:
@@ -90,6 +97,18 @@ Please post it in the issues section of GitHub and we'll fix it as soon as we ca
 Please visit our premium support site at http://www.paidmembershipspro.com for more documentation and our support forums.
 
 == Changelog ==
+
+= 0.7 - 2020-04-29 =
+* SECURITY/ENHANCEMENT: Update NPM packages to latest version to resolve vulnerability issues.
+* BUG FIX: Stripping slashes when using an apostrophe in search field.
+* BUG FIX: Fixed notice and display bug when a trailing space was left in the shortcode's "fields" attribute.
+* BUG FIX/ENHANCEMENT: Replicated error_log for field data code in the "table" layout (logging was already in the other layouts).
+* BUG FIX/ENHANCEMENT: Added `word-break` css improvement for cases where a long name or email address was forcing overflow content.
+* BUG FIX/ENHANCEMENT: Fixed case where a user hidden from directory could still have their individual profile accessed through direct URL.
+* ENHANCEMENT: Support for Multiple Memberships Per User to display comma-separated list of levels in directory and profile view.
+* ENHANCEMENT: Support for frontend member profile edit in PMPro v2.3+ to allow members to toggle display in directory.
+* ENHANCEMENT: Filter added for previous and next page navigation on directory (`pmpromd_pagination_url`).
+
 = .6.1 =
 * BUG FIX: Levels select in block not returning any results.
 * BUG FIX: Custom fields from Register Helper not working when multiple fields are set in the shortcode method.

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Please visit our premium support site at http://www.paidmembershipspro.com for m
 * ENHANCEMENT: Support for Multiple Memberships Per User to display comma-separated list of levels in directory and profile view.
 * ENHANCEMENT: Support for frontend member profile edit in PMPro v2.3+ to allow members to toggle display in directory.
 * ENHANCEMENT: Filter added for previous and next page navigation on directory (`pmpromd_pagination_url`).
+* ENHANCEMENT: Wrapped the filename output on directory or profile with `<span class="pmpromd_filename">` to allow customization or hide via CSS. 
 
 = .6.1 =
 * BUG FIX: Levels select in block not returning any results.

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -22,10 +22,12 @@ function pmpromd_profile_preheader()
 			$pu = $current_user;
 		else
 			$pu = false;
-		
-		//If no profile user or membership level, go to directory or home
-		if(empty($pu) || empty($pu->ID) || !pmpro_hasMembershipLevel(null, $pu->ID))
-		{
+
+		// Is this user hidden from directory?
+		$pmpromd_hide_directory = get_user_meta( $pu->ID, 'pmpromd_hide_directory', true );
+
+		// If no profile user, membership level, or hidden, go to directory or home.
+		if(empty($pu) || empty($pu->ID) || !pmpro_hasMembershipLevel(null, $pu->ID) || $pmpromd_hide_directory == '1' ) {
 			if(!empty($pmpro_pages['directory']))
 				wp_redirect(get_permalink($pmpro_pages['directory']));
 			else
@@ -212,8 +214,14 @@ function pmpromd_profile_shortcode($atts, $content=null, $code="")
 	elseif(empty($_REQUEST['pu']))
 		$pu = get_userdata($current_user->ID);
 
-	if(!empty($pu))
-		$pu->membership_level = pmpro_getMembershipLevelForUser($pu->ID);
+	if ( ! empty( $pu ) ) {
+		$allmylevels = pmpro_getMembershipLevelsForUser( $pu->ID );
+		$membership_levels = array();
+		foreach ( $allmylevels as $curlevel ) {
+			$membership_levels[] = $curlevel->name;
+		}
+		$pu->membership_levels = implode(', ', $membership_levels);
+	}
 
 	ob_start();
 
@@ -294,7 +302,7 @@ function pmpromd_profile_shortcode($atts, $content=null, $code="")
 				<?php if(!empty($show_level)) { ?>										
 					<p class="pmpro_member_directory_level">
 						<strong><?php _e('Level', 'pmpromd'); ?></strong>
-						<?php echo !empty( $pu->membership_level ) ? $pu->membership_level->name : ''; ?>
+						<?php echo ! empty( $pu->membership_levels ) ? $pu->membership_levels : ''; ?>
 					</p>
 				<?php } ?>
 				<?php if(!empty($show_startdate)) { ?>										
@@ -333,7 +341,12 @@ function pmpromd_profile_shortcode($atts, $content=null, $code="")
 						{
 
 							if(empty($field[0]))
-								break;		
+								break;
+
+							// Fix for a trailing space in the 'fields' shortcode attribute.
+							if ( $field[0] === ' ' ) {
+								break;
+							}
 			
 							$meta_field = $pu->{$field[1]};
 


### PR DESCRIPTION
* BUG FIX: Stripping slashes when using an apostrophe in search field. partially fixes bug reported in #55 
* BUG FIX: Fixed notice and display bug when a trailing space was left in the shortcode's "fields" attribute. fixed issue #51 
* BUG FIX: Added `method="post"` to search form on directory page to avoid errors where sites not using pretty permalinks would break. fixed issue #15 
* BUG FIX/ENHANCEMENT: Replicated error_log for field data code in the "table" layout (logging was already in the other layouts). 
* BUG FIX/ENHANCEMENT: Added `word-break` css improvement for cases where a long name or email address was forcing overflow content.
* BUG FIX/ENHANCEMENT: Fixed case where a user hidden from directory could still have their individual profile accessed through direct URL.
* ENHANCEMENT: Support for Multiple Memberships Per User to display comma-separated list of levels in directory and profile view. fixed the replicated issue from #28 
* ENHANCEMENT: Filter added for previous and next page navigation on directory (`pmpromd_pagination_url`). Fixes issue #58  
* ENHANCEMENT: Wrapped the filename output on directory or profile with `<span class="pmpromd_filename">` to allow customization or hide via CSS. fixes issue #54 