### PR TITLE
Removing colon in field label

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -513,7 +513,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 										else
 										{
 											?>
-											<strong><?php echo $field[0]; ?>:</strong>
+											<strong><?php echo $field[0]; ?></strong>
 											<?php echo make_clickable($auser->{$field[1]}); ?>
 											<?php
 										}


### PR DESCRIPTION
In a single place where a field was drawn we had a colon between the field label and the field value.  I've removed this single colon for consistency. Users can place a colon in via the "fields" shortcode attribute OR they can do so with CSS if desired.