### PR TITLE
Filter added to directory attributes

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -209,7 +209,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 			}
 		?>">
 			<?php 
-			$shortcode_atts = array(
+			$shortcode_atts = apply_filters( 'pmpro_member_directory_before_atts', array(
 				'avatar_size' => $avatar_size,
 				'fields' => $fields,
 				'layout' => $layout,
@@ -226,9 +226,10 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 				'show_startdate' => $show_startdate,
 				'avatar_align' => $avatar_align,				
 				'fields_array' => $fields_array
-			);
+			) );
 
 			do_action( 'pmpro_member_directory_before', $sqlQuery, $shortcode_atts ); ?>
+			
 			<?php
 			if($layout == "table")
 			{

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -212,7 +212,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 			/**
 			 * Include the default level billing price at checkout as a radio checkbox.
 			 * 
-			 * @param array Contain all of the shortcode attributes used in the directory shortcode
+			 * @param array Contains all of the shortcode attributes used in the directory shortcode
 			 */
 			$shortcode_atts = apply_filters( 'pmpro_member_directory_atts', array(
 				'avatar_size' => $avatar_size,

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -209,7 +209,12 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 			}
 		?>">
 			<?php 
-			$shortcode_atts = apply_filters( 'pmpro_member_directory_before_atts', array(
+			/**
+			 * Include the default level billing price at checkout as a radio checkbox.
+			 * 
+			 * @param array Contain all of the shortcode attributes used in the directory shortcode
+			 */
+			$shortcode_atts = apply_filters( 'pmpro_member_directory_atts', array(
 				'avatar_size' => $avatar_size,
 				'fields' => $fields,
 				'layout' => $layout,

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -210,7 +210,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 		?>">
 			<?php 
 			/**
-			 * Include the default level billing price at checkout as a radio checkbox.
+			 * Filter to override the attributes passed into the shortcode.
 			 * 
 			 * @param array Contains all of the shortcode attributes used in the directory shortcode
 			 */


### PR DESCRIPTION
Relates to https://github.com/strangerstudios/pmpro-membership-maps/issues/24

Filter added to the array that feeds into the before member directory action. Needed in Membership Maps

Changelog: 

- New filter added `pmpro_member_directory_before_atts` to filter attributes in the `pmpro_member_directory_before` action.