### PR TITLE
add pu filter

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -143,6 +143,19 @@ function pmpro_member_directory_get_member_display_name( $user ) {
 	return $display_name;
 }
 
+/**
+ * Filters the name to display in the profile URL (pu) query string parameter.
+ *
+ * @since 1.2
+ *
+ * @param object $user The WP_User object for the profile.
+ * @param string $profile_url_name The name to display in the profile URL (pu) query string parameter.
+ */
+function pmpro_member_directory_get_member_profile_url_name( $user ) {
+	$profile_url_name = apply_filters( 'pmpro_member_directory_profile_url_name', $user->user_nicename, $user );
+	return $profile_url_name;
+}
+
 /*
 Function to add links to the plugin row meta
 */

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -280,7 +280,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 							<?php if(!empty($show_avatar)) { ?>
 								<td class="pmpro_member_directory_avatar">
 									<?php if(!empty($link) && !empty($profile_url)) { ?>
-										<a href="<?php echo add_query_arg('pu', $auser->user_nicename, $profile_url); ?>"><?php echo get_avatar( $auser->ID, $avatar_size, NULL, $auser->user_nicename ); ?></a>
+										<a href="<?php echo add_query_arg('pu', pmpro_member_directory_get_member_profile_url_name( $auser ), $profile_url); ?>"><?php echo get_avatar( $auser->ID, $avatar_size, NULL, $auser->user_nicename ); ?></a>
 									<?php } else { ?>
 										<?php echo get_avatar( $auser->ID, $avatar_size, NULL, $auser->user_nicename ); ?>
 									<?php } ?>
@@ -289,7 +289,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 							<td>
 								<h3 class="pmpro_member_directory_display-name">
 									<?php if(!empty($link) && !empty($profile_url)) { ?>
-										<a href="<?php echo add_query_arg('pu', $auser->user_nicename, $profile_url); ?>"><?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
+										<a href="<?php echo add_query_arg('pu', pmpro_member_directory_get_member_profile_url_name( $auser ), $profile_url); ?>"><?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
 									<?php } else { ?>
 										<?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?>
 									<?php } ?>
@@ -411,7 +411,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 							<?php } ?>
 							<?php if(!empty($link) && !empty($profile_url)) { ?>
 								<td class="pmpro_member_directory_link">
-									<a href="<?php echo add_query_arg('pu', $auser->user_nicename, $profile_url); ?>"><?php _e('View Profile','pmpromd'); ?></a>
+									<a href="<?php echo add_query_arg('pu', pmpro_member_directory_get_member_profile_url_name( $auser ), $profile_url); ?>"><?php _e('View Profile','pmpromd'); ?></a>
 								</td>
 							<?php } ?>
 						</tr>
@@ -432,7 +432,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 						<?php if(!empty($show_avatar)) { ?>
 							<div class="pmpro_member_directory_avatar">
 								<?php if(!empty($link) && !empty($profile_url)) { ?>
-									<a class="<?php echo $avatar_align; ?>" href="<?php echo add_query_arg('pu', $auser->user_nicename, $profile_url); ?>"><?php echo get_avatar($auser->ID, $avatar_size, NULL, $auser->display_name); ?></a>
+									<a class="<?php echo $avatar_align; ?>" href="<?php echo add_query_arg('pu', pmpro_member_directory_get_member_profile_url_name( $auser ), $profile_url); ?>"><?php echo get_avatar($auser->ID, $avatar_size, NULL, $auser->display_name); ?></a>
 								<?php } else { ?>
 									<span class="<?php echo $avatar_align; ?>"><?php echo get_avatar($auser->ID, $avatar_size, NULL, $auser->display_name); ?></span>
 								<?php } ?>
@@ -440,7 +440,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 						<?php } ?>
 						<h3 class="pmpro_member_directory_display-name">
 							<?php if(!empty($link) && !empty($profile_url)) { ?>
-								<a href="<?php echo add_query_arg('pu', $auser->user_nicename, $profile_url); ?>"><?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
+								<a href="<?php echo add_query_arg('pu', pmpro_member_directory_get_member_profile_url_name( $auser ), $profile_url); ?>"><?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
 							<?php } else { ?>
 								<?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
 							<?php } ?>
@@ -549,7 +549,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 						?>
 						<?php if(!empty($link) && !empty($profile_url)) { ?>
 							<p class="pmpro_member_directory_link">
-								<a class="more-link" href="<?php echo add_query_arg('pu', $auser->user_nicename, $profile_url); ?>"><?php _e('View Profile','pmpromd'); ?></a>
+								<a class="more-link" href="<?php echo add_query_arg('pu', pmpro_member_directory_get_member_profile_url_name( $auser ), $profile_url); ?>"><?php _e('View Profile','pmpromd'); ?></a>
 							</p>
 						<?php } ?>
 					</div> <!-- end pmpro_member_directory-item -->


### PR DESCRIPTION
Add a filter that allows setting the value for the profile URL `pu` parameter.

The Profile page checks this value against a user's user ID and nicename, whereas the Directory page uses the user's nicename for the parameter. This filter will allow using the user's ID for the profile URL `pu` parameter.

Sample Implementation of this filter:

```php
function my_pmpro_member_directory_use_user_id_for_profile_url( $profile_url_name, $user ) {
	$profile_url_name = $user->ID;
	return $profile_url_name;
}
add_filter( 'pmpro_member_directory_profile_url_name', 'my_pmpro_member_directory_use_user_id_for_profile_url', 10, 2 );
```

This PR is part of the [discussion for future enhancements](https://github.com/strangerstudios/pmpro-member-directory/issues/87)