### PR TITLE
Fix for saving extra profile fields

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -99,7 +99,7 @@ function pmpromd_save_extra_profile_fields( $user_id ) {
 		
 
 	if ( is_page( $pmpro_pages['member_profile_edit'] ) ) {
-		if ( ! isset( $_REQUEST['submit'] ) ) {
+		if ( ! isset( $_REQUEST['action'] ) || $_REQUEST['action'] !== 'update-profile' ) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Fix: change the update action check as the submit button is disabled by `wp-content/plugins/paid-memberships-pro/js/pmpro-checkout.js:132` in 
```
       // Find ALL <form> tags on your page
	jQuery('form').submit(function(){
		// On submit disable its submit button
		jQuery('input[type=submit]', this).attr('disabled', 'disabled');
		jQuery('input[type=image]', this).attr('disabled', 'disabled');
		jQuery('#pmpro_processing_message').css('visibility', 'visible');
	});
```