### PR TITLE
Changed the way we make things clickable

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -188,7 +188,7 @@ function pmpromd_make_clickable( $url, $field = false ){
 
 	} else if ( apply_filters( 'pmpromd_make_clickable', false, $field ) ) {
 
-		return make_clickable($url);
+		return make_clickable( wp_kses_post( $url ) );
 
 	} else {
 

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -158,3 +158,35 @@ function pmpromd_plugin_row_meta($links, $file) {
 	return $links;
 }
 add_filter('plugin_row_meta', 'pmpromd_plugin_row_meta', 10, 2);
+
+/**
+ * Should we make something clickable. Filters included
+ */
+function pmpromd_make_clickable( $url, $field = false ){
+
+	/**
+	 * Logic follows:
+	 * 1) Do we want to make it an oembed URL, if yes, do it. If not, check pt2
+	 * 2) Do we want to make it clickable. If yes, do it. If not, check pt3
+	 * 3) Just return a string/URL
+	 */
+	if( apply_filters( 'pmpromd_make_clickable_oembed', true, $field ) ) {
+		
+		$url_embed = wp_oembed_get($url);
+		if( !empty( $url_embed ) ){
+			return $url_embed;
+		}
+
+		return $url;
+
+	} else if ( apply_filters( 'pmpromd_make_clickable', false, $field ) ) {
+
+		return make_clickable($url);
+
+	} else {
+
+		return apply_filters( 'pmpromd_make_clickable_url', $url, $field );
+
+	}
+
+}

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -192,7 +192,9 @@ function pmpromd_make_clickable( $url, $field = false ){
 
 	} else {
 
-		return apply_filters( 'pmpromd_make_clickable_url', $url, $field );
+		$url = apply_filters( 'pmpromd_make_clickable_url', $url, $field );
+
+		return esc_html( $url );
 
 	}
 

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -160,7 +160,14 @@ function pmpromd_plugin_row_meta($links, $file) {
 add_filter('plugin_row_meta', 'pmpromd_plugin_row_meta', 10, 2);
 
 /**
- * Should we make something clickable. Filters included
+ * Should we make something clickable. Filters included.
+ *
+ * @since TBD
+ *
+ * @param string      $url   The URL to maybe make clickable or run oembed for.
+ * @param false|array $field The field array information.
+ *
+ * @return string The output that may have been clickable or embedded.
  */
 function pmpromd_make_clickable( $url, $field = false ){
 

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -297,7 +297,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 							</td>
 							<?php if(!empty($show_email)) { ?>
 								<td class="pmpro_member_directory_email">
-									<?php echo $auser->user_email; ?>
+									<?php echo pmpromd_make_clickable( $auser->user_email ); ?>
 								</td>
 							<?php } ?>
 							<?php
@@ -361,11 +361,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 														?>
 														<strong><?php echo $field[0]; ?></strong>
 														<?php
-														$meta_field_embed = wp_oembed_get($meta_field);
-														if(!empty($meta_field_embed))
-															echo $meta_field_embed;
-														else
-															echo make_clickable($meta_field);
+															echo pmpromd_make_clickable( $meta_field );
 														?>
 														<?php
 													}
@@ -448,7 +444,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 						<?php if(!empty($show_email)) { ?>
 							<p class="pmpro_member_directory_email">
 								<strong><?php _e('Email Address', 'pmpromd'); ?></strong>
-								<?php echo $auser->user_email; ?>
+								<?php echo pmpromd_make_clickable( $auser->user_email ); ?>
 							</p>
 						<?php } ?>
 						<?php if(!empty($show_level)) { ?>
@@ -530,14 +526,14 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 										elseif($field[1] == 'user_url')
 										{
 											?>
-											<a href="<?php echo $auser->{$field[1]}; ?>" target="_blank"><?php echo $field[0]; ?></a>
+											<a href="<?php echo $auser->{$field[1]}; ?>" target="_blank"><?php echo pmpromd_make_clickable( $field[0], $field ); ?></a>
 											<?php
 										}
 										else
 										{
 											?>
 											<strong><?php echo $field[0]; ?></strong>
-											<?php echo make_clickable($auser->{$field[1]}); ?>
+											<?php echo pmpromd_make_clickable( $auser->{$field[1]}, $field ); ?>
 											<?php
 										}
 										?>

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -526,7 +526,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 										elseif($field[1] == 'user_url')
 										{
 											?>
-											<a href="<?php echo $auser->{$field[1]}; ?>" target="_blank"><?php echo pmpromd_make_clickable( $field[0], $field ); ?></a>
+											<a href="<?php echo esc_url( $auser->{$field[1]} ); ?>" target="_blank"><?php echo pmpromd_make_clickable( $field[0], $field ); ?></a>
 											<?php
 										}
 										else


### PR DESCRIPTION
New function added `pmpromd_make_clickable` where we check if 3 different filters are set. 

This applies to email addresses and the user_url link. 
`
Logic follows:
1) Do we want to make it an oembed URL, if yes, do it. If not, check pt2
2) Do we want to make it clickable. If yes, do it. If not, check pt3
3) Just return a string/URL

New filters are:

pmpromd_make_clickable_oembed (default set to true)
pmpromd_make_clickable (default set to faulse)
pmpromd_make_clickable_url (default is URL string)