### PR TITLE
Profile title filtering adjusted to not reflect in menu

### DIFF
--- a/templates/profile.php
+++ b/templates/profile.php
@@ -130,8 +130,8 @@ function pmpromd_profile_preheader()
 		 */
 		function pmpromd_readd_filters_menu_title( $items, $args ) {
 		    // we are done working with menu, so add the title filter back
-		    add_filter("wp_title", "pmpromd_wp_title", 10, 2);
-		    add_filter("the_title", "pmpromd_the_title", 10, 2);
+		    add_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
+		    add_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
 		    return $items;
 		}
 		add_filter( 'wp_nav_menu_items', 'pmpromd_readd_filters_menu_title', 10, 2 );

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -116,9 +116,16 @@ function pmpromd_profile_preheader()
 		add_filter("wp_title", "pmpromd_wp_title", 10, 2);
 
 		/**
-		 * We're working with the menu now so remove the filters
+		 * We're working with the menu now so remove the filters.
+		 *
+		 * @since TBD
+		 *
+		 * @param string|null $output Nav menu output to short-circuit with. Default null.
+		 *
+		 * @return string|null Nav menu output to short-circuit with. Default null.
 		 */
-		function pmpromd_remove_filters_menu_title( $nav_menu, $args ) {	
+		function pmpromd_remove_filters_menu_title( $nav_menu ) {	
+
 		    remove_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
 		    remove_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
 		    return $nav_menu;

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -130,7 +130,8 @@ function pmpromd_profile_preheader()
 		    remove_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
 		    return $nav_menu;
 		}
-		add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_filters_menu_title', 10, 2 );
+		add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_filters_menu_title' );
+
 
 		/**
 		 * We're done working with the menu so add those filters back.

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -126,9 +126,16 @@ function pmpromd_profile_preheader()
 		add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_filters_menu_title', 10, 2 );
 
 		/**
-		 * We're done working with the menu so add those filters back
+		 * We're done working with the menu so add those filters back.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $items The HTML list content for the menu items.
+		 *
+		 * @return string The HTML list content for the menu items.
 		 */
-		function pmpromd_readd_filters_menu_title( $items, $args ) {
+		function pmpromd_readd_filters_menu_title( $items ) {
+
 		    // we are done working with menu, so add the title filter back
 		    add_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
 		    add_filter( 'the_title', 'pmpromd_the_title', 10, 2 );

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -149,7 +149,8 @@ function pmpromd_profile_preheader()
 		    add_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
 		    return $items;
 		}
-		add_filter( 'wp_nav_menu_items', 'pmpromd_readd_filters_menu_title', 10, 2 );
+		add_filter( 'wp_nav_menu_items', 'pmpromd_readd_filters_menu_title' );
+
 
 	}
 }

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -114,6 +114,28 @@ function pmpromd_profile_preheader()
 			return $title;
 		}
 		add_filter("wp_title", "pmpromd_wp_title", 10, 2);
+
+		/**
+		 * We're working with the menu now so remove the filters
+		 */
+		function pmpromd_remove_filters_menu_title( $nav_menu, $args ) {	
+		    remove_filter("wp_title", "pmpromd_wp_title", 10, 2);
+		    remove_filter("the_title", "pmpromd_the_title", 10, 2);
+		    return $nav_menu;
+		}
+		add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_filters_menu_title', 10, 2 );
+
+		/**
+		 * We're done working with the menu so add those filters back
+		 */
+		function pmpromd_readd_filters_menu_title( $items, $args ) {
+		    // we are done working with menu, so add the title filter back
+		    add_filter("wp_title", "pmpromd_wp_title", 10, 2);
+		    add_filter("the_title", "pmpromd_the_title", 10, 2);
+		    return $items;
+		}
+		add_filter( 'wp_nav_menu_items', 'pmpromd_readd_filters_menu_title', 10, 2 );
+
 	}
 }
 add_action("wp", "pmpromd_profile_preheader", 1);

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -119,8 +119,8 @@ function pmpromd_profile_preheader()
 		 * We're working with the menu now so remove the filters
 		 */
 		function pmpromd_remove_filters_menu_title( $nav_menu, $args ) {	
-		    remove_filter("wp_title", "pmpromd_wp_title", 10, 2);
-		    remove_filter("the_title", "pmpromd_the_title", 10, 2);
+		    remove_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
+		    remove_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
 		    return $nav_menu;
 		}
 		add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_filters_menu_title', 10, 2 );


### PR DESCRIPTION
Relates to #75

The current profile title gets filtered like this: 

![current-profile-title](https://user-images.githubusercontent.com/8989542/153201568-87eeb4a1-22d7-40dc-a93a-608b4a143cfb.PNG)

We now don't filter the title in the menu as this is unnecessary

![after-menu](https://user-images.githubusercontent.com/8989542/153201655-cee199ad-f7e1-4cff-9d84-1d60f55faf27.PNG)

