### PR TITLE
Filter fields based on level

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -158,3 +158,52 @@ function pmpromd_plugin_row_meta($links, $file) {
 	return $links;
 }
 add_filter('plugin_row_meta', 'pmpromd_plugin_row_meta', 10, 2);
+
+/**
+ * Filters through the fields we're expecting to show and make sure the user has the required level
+ * 
+ * @param  array $profile_fields The fields we want to display on the page
+ * @param  object $pu             The current user object
+ * @return array Returns the fields we want to show
+ */
+function pmpromd_filter_profile_fields_for_levels( $profile_fields, $pu ) {
+
+	global $pmprorh_registration_fields;
+
+	$fields_to_hide = array();
+
+	if(!empty($pmprorh_registration_fields)) {
+		
+		//Loop through all of the RH fields
+		foreach($pmprorh_registration_fields as $where => $fields) {
+
+			//cycle through fields
+			foreach($fields as $field){
+				//Check if there are any levels associated with this field	
+				if( !empty( $field->levels ) ){
+					//Check if the member has the required level to view this
+					if( !pmpro_hasMembershipLevel( $field->levels, $pu->ID ) ){
+						//If not, lets hide this field from them
+						$fields_to_hide[] = $field->name;
+					}
+				}
+				
+				
+			}
+
+		}
+	}
+	$fields_to_show = array();
+	//Lets loop through all of the profile fields that we 'should' display
+	foreach( $profile_fields as $field_array ){
+		//Check if the current field is in the fields_to_hide array
+		if( !in_array( $field_array[1], $fields_to_hide ) ) {
+			//It isn't in the array so we want to show this field
+			$fields_to_show[] = $field_array;
+		}
+	}
+
+	return $fields_to_show;
+
+}
+add_filter( 'pmpro_member_profile_fields', 'pmpromd_filter_profile_fields_for_levels', 10, 2 );

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -160,11 +160,14 @@ function pmpromd_plugin_row_meta($links, $file) {
 add_filter('plugin_row_meta', 'pmpromd_plugin_row_meta', 10, 2);
 
 /**
- * Filters through the fields we're expecting to show and make sure the user has the required level
+ * Filter the fields we are expecting to show and make sure the user has the required level.
+ *
+ * @since TBD
  * 
- * @param  array $profile_fields The fields we want to display on the page
- * @param  object $pu             The current user object
- * @return array Returns the fields we want to show
+ * @param array  $profile_fields The list of fields we want to display on the page.
+ * @param object $pu             The current user object.
+ *
+ * @return array The list of fields we want to display on the page.
  */
 function pmpromd_filter_profile_fields_for_levels( $profile_fields, $pu ) {
 

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -207,3 +207,4 @@ function pmpromd_filter_profile_fields_for_levels( $profile_fields, $pu ) {
 
 }
 add_filter( 'pmpro_member_profile_fields', 'pmpromd_filter_profile_fields_for_levels', 10, 2 );
+add_filter( 'pmpro_member_directory_fields', 'pmpromd_filter_profile_fields_for_levels', 10, 2 );

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -192,6 +192,10 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 		else
 			$fields_array = false;
 
+
+		//filter the fields
+		$fields_array = apply_filters( 'pmpro_member_directory_fields', $fields_array, $pu );
+
 		// Get Register Helper field options
 		$rh_fields = array();
 		if(!empty($pmprorh_registration_fields)) {

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -194,7 +194,14 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 
 
 		//filter the fields
-		$fields_array = apply_filters( 'pmpro_member_directory_fields', $fields_array, $pu );
+		/**
+		 * Allow filtering the fields to include on the member directory list.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $fields_array The list of fields to include.
+		 */
+		$fields_array = apply_filters( 'pmpro_member_directory_fields', $fields_array );
 
 		// Get Register Helper field options
 		$rh_fields = array();

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -193,7 +193,6 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 			$fields_array = false;
 
 
-		//filter the fields
 		/**
 		 * Allow filtering the fields to include on the member directory list.
 		 *


### PR DESCRIPTION
Relates to #16 

We now filter the RH fields to ensure that that specific member has the required level to show a specific level (if that level has the array key of levels assigned to it in RH)

A new filter has been added in the directory `pmpro_member_directory_fields` to achieve the same. 