### PR TITLE
Fallbacks added for when PMPro is inactive

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -395,7 +395,7 @@ function pmpromd_custom_rewrite_rules() {
 
 	global $pmpro_pages;
 
-	if( empty( $pmpro_pages ) ) {
+	if ( empty( $pmpro_pages ) ) {
 		return;
 	}
 
@@ -539,7 +539,7 @@ function pmpromd_build_profile_url( $pu, $profile_url = false, $separator = fals
  */
 function pmpromd_check_for_upgrade() {
 
-	if( !function_exists( 'pmpro_getOption' ) ) {
+	if ( ! function_exists( 'pmpro_getOption' ) ) {
 		return;
 	}
 

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -395,6 +395,10 @@ function pmpromd_custom_rewrite_rules() {
 
 	global $pmpro_pages;
 
+	if( empty( $pmpro_pages ) ) {
+		return;
+	}
+
 	$parent_id = get_post_field( 'post_parent', $pmpro_pages['profile'] );
 	$slug = get_post_field( 'post_name',  $pmpro_pages['profile'] );
 
@@ -534,6 +538,10 @@ function pmpromd_build_profile_url( $pu, $profile_url = false, $separator = fals
  * @return void
  */
 function pmpromd_check_for_upgrade() {
+
+	if( !function_exists( 'pmpro_getOption' ) ) {
+		return;
+	}
 
 	$pmpromd_db_version = pmpro_getOption("md_db_version");
 


### PR DESCRIPTION
Resolves #118

Prevents 2 errors when PMPro inactive

```
PHP Fatal error: Uncaught Error: Call to undefined function pmpro_getOption() in /path/wp-content/plugins/pmpro-member-directory/pmpro-member-directory.php:538
```

Undefined array within the `pmpromd_custom_rewrite_rules` function