### PR TITLE
Adjusted how rewrite rules are created

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -395,24 +395,25 @@ function pmpromd_custom_rewrite_rules() {
 
 	global $pmpro_pages;
 
-	$parent_id = get_post_field( 'post_parent', $pmpro_pages['profile'] );
-	$slug = get_post_field( 'post_name',  $pmpro_pages['profile'] );
-
-	if( !empty( $parent_id ) ){
-		$parent_slug = get_post_field( 'post_name',  $parent_id );
-		$profile_base = $parent_slug.'/'.$slug;
-	} else {
-		$profile_base = $slug;
+	if( empty( $pmpro_pages ) ) {
+		return;
 	}
 
+	$profile_permalink = get_the_permalink( $pmpro_pages['profile'] );
+
+	$base_site_url = get_site_url();
+
+	$profile_base = str_replace( $base_site_url.'/', '', $profile_permalink );
+
 	add_rewrite_rule(
-		$profile_base.'/([^/]+)/?$',
+		$profile_base.'([^/]+)/?$',
 		'index.php?pagename='.$profile_base.'&pu=$matches[1]',
 		'top'
 	);
 
 }
 add_action('init', 'pmpromd_custom_rewrite_rules', 10 );
+
 
 /**
  * Adding in the ?pu parameter so that we can retrieve the value from the pretty permalink

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -395,7 +395,7 @@ function pmpromd_custom_rewrite_rules() {
 
 	global $pmpro_pages;
 
-	if( empty( $pmpro_pages ) ) {
+	if ( empty( $pmpro_pages ) ) {
 		return;
 	}
 
@@ -403,11 +403,11 @@ function pmpromd_custom_rewrite_rules() {
 
 	$base_site_url = get_site_url();
 
-	$profile_base = str_replace( $base_site_url.'/', '', $profile_permalink );
+	$profile_base = str_replace( $base_site_url . '/', '', $profile_permalink );
 
 	add_rewrite_rule(
 		$profile_base.'([^/]+)/?$',
-		'index.php?pagename='.$profile_base.'&pu=$matches[1]',
+		'index.php?pagename=' . $profile_base . '&pu=$matches[1]',
 		'top'
 	);
 


### PR DESCRIPTION
Resolves #125 

Adjusted how we handle the base URL in our rewrite rules. Pages that are nested more than 1 level cause a 404. This works around it. 

Detail on how to replicate are available in the issue