### PR TITLE
Better profile page checks prevent issues with rewrite rules.

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -394,7 +394,7 @@ function pmpromd_custom_rewrite_rules() {
 
 	global $pmpro_pages;
 
-	if ( empty( $pmpro_pages ) ) {
+	if ( empty( $pmpro_pages ) || empty( $pmpro_pages['profile'] ) ) {
 		return;
 	}
 
@@ -411,7 +411,7 @@ function pmpromd_custom_rewrite_rules() {
 	);
 
 }
-add_action('init', 'pmpromd_custom_rewrite_rules', 10 );
+add_action( 'init', 'pmpromd_custom_rewrite_rules', 10 );
 
 
 /**


### PR DESCRIPTION
We noticed a couple of issues.

(1) Users were sometimes redirected to the homepage when trying to view a page. Viewing a post or different post type worked fine.

(2) Sometimes the blog index view was shown instead of the page content when trying to view a page.

The issue occurred because both the profile page rewrite rule and preheader code were running even if there was no profile page set. This would results in page checks against that 0 page or a rewrite rule set up with an empty slug as the base.

This update adds checks to make sure the code in both these places doesn't load when the profile page is not set.