### PR TITLE
Adds support for user taxonomies on directory and profile

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -366,7 +366,20 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 											?>
 											<p class="pmpro_member_directory_<?php echo $field[1]; ?>">
 												<?php
-												if(is_array($meta_field) && !empty($meta_field['filename']) )
+												if( taxonomy_exists( $field[1] ) ){
+													//This is a custom user taxonomy
+													$user_taxonomies = wp_get_object_terms( $auser->ID, $field[1] );
+													if( ! empty( $user_taxonomies ) ) {
+														?>
+														<strong><?php echo $field[0]; ?></strong>
+														<?php
+														$ut_names = array();
+														foreach( $user_taxonomies as $ut ) {
+															$ut_names[] = $ut->name;
+														}
+														echo implode( ", ", $ut_names );
+													}
+												} else if(is_array($meta_field) && !empty($meta_field['filename']) )
 												{
 													//this is a file field
 													?>
@@ -536,8 +549,20 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 									?>
 									<p class="pmpro_member_directory_<?php echo $field[1]; ?>">
 										<?php
-										if(is_array($meta_field) && !empty($meta_field['filename']) )
-										{
+										if( taxonomy_exists( $field[1] ) ){
+											//This is a custom user taxonomy
+											$user_taxonomies = wp_get_object_terms( $auser->ID, $field[1] );
+											if( ! empty( $user_taxonomies ) ) {
+												?>
+												<strong><?php echo $field[0]; ?></strong>
+												<?php
+												$ut_names = array();
+												foreach( $user_taxonomies as $ut ) {
+													$ut_names[] = $ut->name;
+												}
+												echo implode( ", ", $ut_names );
+											}
+										} else if ( is_array( $meta_field) && ! empty( $meta_field['filename'] ) ) {
 											//this is a file field
 											?>
 											<strong><?php echo $field[0]; ?></strong>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -369,8 +369,21 @@ function pmpromd_profile_shortcode($atts, $content=null, $code="")
 							{
 								?>
 								<p class="pmpro_member_directory_<?php echo esc_attr($field[1]); ?>">
-								<?php
-									if(is_array($meta_field) && !empty($meta_field['filename']) )
+								<?php								
+									if( taxonomy_exists( $field[1] ) ){
+										//This is a custom user taxonomy
+										$user_taxonomies = wp_get_object_terms( $pu->ID, $field[1] );
+										if( ! empty( $user_taxonomies ) ) {
+											?>
+											<strong><?php echo $field[0]; ?></strong>
+											<?php
+											$ut_names = array();
+											foreach( $user_taxonomies as $ut ) {
+												$ut_names[] = $ut->name;
+											}
+											echo implode( ", ", $ut_names );
+										}
+									} else if(is_array($meta_field) && !empty($meta_field['filename']) )
 									{
 										//this is a file field
 										?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for custom taxonomies so that the tax ID does not show on the profile/directory pages but rather the taxonomy name. 

Resolves https://github.com/strangerstudios/pmpro-member-directory/issues/145

### How to test the changes in this Pull Request:

1. Add this recipe to set up multiple custom taxonomies https://github.com/strangerstudios/pmpro-snippets-library/blob/dev/user-fields/custom-user-taxonomy-field.php
2. Directory Shortcode: [pmpro_member_directory fields="Team,team;Title,titles;Rev,revenue;"]
3. Profile Shortcode: [pmpro_member_profile fields="Team,team;Title,titles;Rev,revenue;"]
4. Update a user profile with the new taxonomies
5. The taxonomy labels/names should show and not their stored IDs on both the directory and profile pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Custom user taxonomies now display labels instead of stored IDs