### PR TITLE
Bug Fix - Pagination showed three dots with no page numbers

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -648,7 +648,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 			echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" title="' . esc_attr__( 'Previous', 'pmpromd' ) . '">...</a>';
 		}
 
-		if( round( $number_of_pages, 0 ) === 1 ) {
+		if( round( $number_of_pages, 0 ) !== 1 && $pn !== 1 ) {
 			//If there's only one page, no need to show the page numbers
 			for( $i = $pn; $i <= $number_of_pages+1; $i++ ){
 				if( $counter <= 6 ){

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -650,7 +650,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 
 		if( round( $number_of_pages, 0 ) !== 1 && $pn !== 1 ) {
 			//If there's only one page, no need to show the page numbers
-			for( $i = $pn; $i <= $number_of_pages+1; $i++ ){
+			for( $i = $pn; $i <= $number_of_pages; $i++ ){
 				if( $counter <= 6 ){
 					$query_args = array(
 						'ps' => $s,


### PR DESCRIPTION
The page links only shows 3 dots ... when moving past the first page.

These changes ensure that the page numbers don't show on page 1, but they do show after moving past the first page.

How to test:

- Set the shortcode to a limit of 3 (limit='3')
- Move to the next page, the page number links should show up correctly

Page links before the fix

![member-dir-before](https://user-images.githubusercontent.com/8989542/236442070-ac925174-b231-4cc1-bb7d-a123732b31f0.PNG)

Page links after - on page 1

![member-dir-p1](https://user-images.githubusercontent.com/8989542/236442093-182ddaf8-02b6-428e-bfd4-c53c9244efbd.PNG)

Page links after - on page 2

![member-dir-p2](https://user-images.githubusercontent.com/8989542/236442110-95c36102-fd24-440c-aa89-0c8d2cc06a4e.PNG)
