### PR TITLE
Updating headings hierarchy to match new PMPro checkout page for a11y

### DIFF
--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -1,6 +1,6 @@
 /* CSS Document */
 
-h3#pmpro_member_directory_subheading {clear: none; margin-top: 0; }
+h2#pmpro_member_directory_subheading {clear: none; margin-top: 0; }
 form.pmpro_member_directory_search {float: right; margin-bottom: 1rem; clear: both; }
 form.pmpro_member_directory_search input[type=text] { }
 form.pmpro_member_directory_search input[type=submit] {background: none; border: none; padding: 0; position: absolute; text-indent: -9999em; }
@@ -11,12 +11,12 @@ form.pmpro_member_directory_search input[type=submit] {background: none; border:
 .pmpro_pagination .pmpro_next {float: right; width: 250px; text-align: right;}
 
 /* div/column type layouts */
-div.pmpro_member_directory div h3 {clear: none; }
+div.pmpro_member_directory div h2 {clear: none; }
 div.pmpro_member_directory div p {margin: .5rem 0 0 0; } 
 div.pmpro_member_profile strong {display: block; }
 
 /* table type layouts */
-.pmpro_member_directory table h3.pmpro_member_directory_display-name {margin-top: 0; }
+.pmpro_member_directory table h2.pmpro_member_directory_display-name {margin-top: 0; }
 .pmpro_member_directory table tbody td {vertical-align: top; }
 .pmpro_member_directory table tbody td p {margin: 0 0 .5rem 0; }
 

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -69,7 +69,7 @@ function pmpromd_show_extra_profile_fields($user)
 
 	if ( empty( $pmpro_pages['member_profile_edit'] ) || ! is_page( $pmpro_pages['member_profile_edit'] ) ) {
 ?>
-	<h3><?php echo get_the_title($pmpro_pages['directory']); ?></h3>
+	<h2><?php echo get_the_title($pmpro_pages['directory']); ?></h2>
     <table class="form-table">
         <tbody>
         <tr class="user-hide-directory-wrap">

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -173,7 +173,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 	</form>
 	<?php } ?>
 
-	<h3 id="pmpro_member_directory_subheading">
+	<h2 id="pmpro_member_directory_subheading">
 		<?php if(!empty($s)) { ?>
 			<?php /* translators: placeholder is for search string entered */ ?>
 			<?php printf(__('Profiles Within <em>%s</em>.','pmpro-member-directory'), stripslashes( ucwords(esc_html($s)))); ?>
@@ -191,7 +191,7 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 				?>)
 			</small>
 		<?php } ?>
-	</h3>
+	</h2>
 	<?php
 	if(!empty($theusers))
 	{
@@ -330,13 +330,13 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 								</td>
 							<?php } ?>
 							<td>
-								<h3 class="pmpro_member_directory_display-name">
+								<h2 class="pmpro_member_directory_display-name">
 									<?php if(!empty($link) && !empty($profile_url)) { ?>
 										<a href="<?php echo esc_url( pmpromd_build_profile_url( $auser, $profile_url ), $profile_url, true ); ?>"><?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
 									<?php } else { ?>
 										<?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?>
 									<?php } ?>
-								</h3>
+								</h2>
 							</td>
 							<?php if(!empty($show_email)) { ?>
 								<td class="pmpro_member_directory_email">
@@ -480,13 +480,13 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 								<?php } ?>
 							</div>
 						<?php } ?>
-						<h3 class="pmpro_member_directory_display-name">
+						<h2 class="pmpro_member_directory_display-name">
 							<?php if(!empty($link) && !empty($profile_url)) { ?>
 								<a href="<?php echo esc_url( pmpromd_build_profile_url( $auser ), $profile_url ); ?>"><?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
 							<?php } else { ?>
 								<?php echo esc_html( pmpro_member_directory_get_member_display_name( $auser ) ); ?></a>
 							<?php } ?>
-						</h3>
+						</h2>
 						<?php if(!empty($show_email)) { ?>
 							<p class="pmpro_member_directory_email">
 								<strong><?php _e('Email Address', 'pmpromd'); ?></strong>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.