### PR TITLE
Strip shortcode from posts or pages.

### DIFF
--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -576,7 +576,7 @@ add_action( 'admin_init', 'pmpromd_check_for_upgrade' );
  *
  * @return mixed The content with the shortcode removed. Will be the same type as the input.
  */
-function pmpromd_maybe_strip_member_shortcode( $content ) {
+function pmpromd_maybe_strip_shortcodes( $content ) {
 	// If the user can edit users, we don't need to strip the shortcode.
 	if ( current_user_can( 'edit_users' ) ) {
 		return $content;
@@ -585,7 +585,7 @@ function pmpromd_maybe_strip_member_shortcode( $content ) {
 	// If an array is passed in, filter all elements recursively.
 	if ( is_array( $content ) ) {
 		foreach ( $content as $key => $value ) {
-			$content[ $key ] = pmpromd_maybe_strip_member_shortcode( $value );
+			$content[ $key ] = pmpromd_maybe_strip_shortcodes( $value );
 		}
 		return $content;
 	}
@@ -610,9 +610,9 @@ function pmpromd_maybe_strip_member_shortcode( $content ) {
 
 	return $content;
 }
-add_filter( 'content_save_pre', 'pmpromd_maybe_strip_member_shortcode' );
-add_filter( 'excerpt_save_pre', 'pmpromd_maybe_strip_member_shortcode' );
-add_filter( 'widget_update_callback', 'pmpromd_maybe_strip_member_shortcode' );
+add_filter( 'content_save_pre', 'pmpromd_maybe_strip_shortcodes' );
+add_filter( 'excerpt_save_pre', 'pmpromd_maybe_strip_shortcodes' );
+add_filter( 'widget_update_callback', 'pmpromd_maybe_strip_shortcodes' );
 
 /**
  * Only allow those with the edit_users capability
@@ -625,18 +625,18 @@ add_filter( 'widget_update_callback', 'pmpromd_maybe_strip_member_shortcode' );
  * @param mixed  $_meta_value Meta value.
  * @return void
  */
-function pmpromd_maybe_strip_member_shortcode_from_post_meta( $meta_id, $object_id, $meta_key, $_meta_value ) {
+function pmpromd_maybe_strip_shortcodes_from_post_meta( $meta_id, $object_id, $meta_key, $_meta_value ) {
 	// Bail if the value is not a string or array.
 	if ( ! is_string( $_meta_value ) && ! is_array( $_meta_value ) ) {
 		return;
 	}
 
 	// Strip the shortcode from the meta value.
-	$stripped_value = pmpromd_maybe_strip_member_shortcode( $_meta_value );
+	$stripped_value = pmpromd_maybe_strip_shortcodes( $_meta_value );
 
 	// If there was a change, save our stripped version.
 	if ( $stripped_value !== $_meta_value ) {
 		update_post_meta( $object_id, $meta_key, $stripped_value );
 	}
 }
-add_action( 'updated_post_meta', 'pmpromd_maybe_strip_member_shortcode_from_post_meta', 10, 4 );
+add_action( 'updated_post_meta', 'pmpromd_maybe_strip_shortcodes_from_post_meta', 10, 4 );

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -568,3 +568,75 @@ function pmpromd_check_for_upgrade() {
 
 }
 add_action( 'admin_init', 'pmpromd_check_for_upgrade' );
+
+/**
+ * Strip the [pmpro_member_directory] or [pmpro_member_profile] shortcode and blocks from content if the current user can't edit users.
+ *
+ * @since TBD
+ *
+ * @return mixed The content with the shortcode removed. Will be the same type as the input.
+ */
+function pmpromd_maybe_strip_member_shortcode( $content ) {
+	// If the user can edit users, we don't need to strip the shortcode.
+	if ( current_user_can( 'edit_users' ) ) {
+		return $content;
+	}
+
+	// If an array is passed in, filter all elements recursively.
+	if ( is_array( $content ) ) {
+		foreach ( $content as $key => $value ) {
+			$content[ $key ] = pmpromd_maybe_strip_member_shortcode( $value );
+		}
+		return $content;
+	}
+
+	// If we're not looking at a string, just return it.
+	if ( ! is_string( $content ) ) {
+		return $content;
+	}
+	
+	// Okay, we have a string, figure out the regex.
+	$shortcodeRegex = get_shortcode_regex( array( 'pmpro_member_directory', 'pmpro_member_profile' ) );	
+
+	// Remove various blocks.
+	$blockWrapperPatterns = array(
+		"<!-- wp:pmpro-member-directory/directory /-->",
+		"<!-- wp:pmpro-member-directory/profile /-->",
+		"/<!-- wp:shortcode -->\s*$shortcodeRegex\s*<!-- \/wp:shortcode -->/s",
+		"/$shortcodeRegex/"
+	);
+
+	$content = preg_replace( $blockWrapperPatterns, '', $content );
+
+	return $content;
+}
+add_filter( 'content_save_pre', 'pmpromd_maybe_strip_member_shortcode' );
+add_filter( 'excerpt_save_pre', 'pmpromd_maybe_strip_member_shortcode' );
+add_filter( 'widget_update_callback', 'pmpromd_maybe_strip_member_shortcode' );
+
+/**
+ * Only allow those with the edit_users capability
+ * to use the Directory or Profile shortcodes in post_meta.
+ *
+ * @since TBD
+ * @param int    $meta_id     ID of the meta data entry.
+ * @param int    $object_id   ID of the object the meta is attached to.
+ * @param string $meta_key    Meta key.
+ * @param mixed  $_meta_value Meta value.
+ * @return void
+ */
+function pmpromd_maybe_strip_member_shortcode_from_post_meta( $meta_id, $object_id, $meta_key, $_meta_value ) {
+	// Bail if the value is not a string or array.
+	if ( ! is_string( $_meta_value ) && ! is_array( $_meta_value ) ) {
+		return;
+	}
+
+	// Strip the shortcode from the meta value.
+	$stripped_value = pmpromd_maybe_strip_member_shortcode( $_meta_value );
+
+	// If there was a change, save our stripped version.
+	if ( $stripped_value !== $_meta_value ) {
+		update_post_meta( $object_id, $meta_key, $stripped_value );
+	}
+}
+add_action( 'updated_post_meta', 'pmpromd_maybe_strip_member_shortcode_from_post_meta', 10, 4 );


### PR DESCRIPTION
* SECURITY: Remove the shortcode if the person editing the post doesn't have edit_users capability.