### PR TITLE
Initial work toward the improved directory and profile shortcodes; functions to get display values

### DIFF
--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -86,6 +86,8 @@ div.pmpro_member_profile strong {display: block; }
 .pmpro_member_profile {
 
 	.pmpro_card_content {
+		display: flex;
+		flex-wrap: wrap;
 		gap: var(--pmpro--base--spacing--medium);
 		margin-top: var(--pmpro--base--spacing--medium);
 

--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -86,12 +86,30 @@ div.pmpro_member_profile strong {display: block; }
 .pmpro_member_profile {
 
 	.pmpro_card_content {
-		display: flex;
-		flex-direction: column;
 		gap: var(--pmpro--base--spacing--medium);
 		margin-top: var(--pmpro--base--spacing--medium);
+
+		.pmpro_member_profile_field {
+			box-sizing: border-box;
+			flex: 1 1 calc(50% - var(--pmpro--base--spacing--medium));
+		}
+
+		.pmpro_member_profile_field_label {
+			font-weight: 700;
+		}
+
+		/* Full width profile items */
+		.pmpro_member_profile_field-display_name,
+		.pmpro_member_profile_field-description {
+			flex: 1 1 100%;
+		}
+
+		.pmpro_member_profile_field-display_name h2 {
+			margin: 0;
+		}
 	}
 }
+
 .pmpro_member_profile .pmpromd_filename {
 	display: block;
 }

--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -37,25 +37,23 @@ div.pmpro_member_profile strong {display: block; }
 	.pmpro_card {
 		margin: 0;
 
-		.pmpro_card_title a {
-			text-decoration: none;
-		}
-		.pmpro_card_title a:hover {
-			text-decoration: underline;
-		}
-
-		.pmpro_card_title.pmpro_heading-avatar-right {
-			flex-direction: row-reverse;
-			justify-content: space-between;
-		}
-		.pmpro_card_title.pmpro_heading-avatar-top {
-			align-items: flex-start;
-			flex-direction: column;
-		}
 		.pmpro_card_content {
 			display: flex;
 			flex-direction: column;
 			gap: var(--pmpro--base--spacing--small);
+			margin-top: var(--pmpro--base--spacing--medium);
+
+			.pmpro_member_profile_field_label {
+				font-weight: 700;
+			}
+
+			.pmpro_member_profile_field-display_name {
+
+				h2 {
+					font-weight: 700;
+					margin: 0;
+				}
+			}
 		}
 
 		.pmpro_card_actions {
@@ -74,12 +72,18 @@ div.pmpro_member_profile strong {display: block; }
 }
 
 /* single directory item in list */
-.pmpro_member_directory .pmpro_member_directory-item,
-.pmpro_member_directory .pmpro_member_directory_row {
-	word-break: break-word;
-}
-.pmpro_member_directory_link {
-	word-break: normal;
+.pmpro_member_directory {
+	.pmpro_member_directory-item {
+		word-break: break-word;
+	}
+
+	.pmpro_member_directory_row {
+		word-break: break-word;
+	}
+
+	.pmpro_member_directory_link {
+		word-break: normal;
+	}
 }
 
 /* single profile item */
@@ -127,6 +131,43 @@ div.pmpro_member_profile strong {display: block; }
 /**
  * Pagination/page numbers
  */
+.pmpro_member_directory_pagination {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: var(--pmpro--base--spacing--small);
+	margin: var(--pmpro--base--spacing--medium) 0;
+
+	a {
+		background-color: var(--pmpro--color--base);
+		border: 1px solid var(--pmpro--color--border--variation);
+		border-radius: var(--pmpro--base--border-radius);
+		color: var(--pmpro--color--contrast);
+		padding: 2px var(--pmpro--base--spacing--small);
+		text-decoration: none;
+		transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+
+		&:hover {
+			background-color: var(--pmpro--color--accent--variation);
+			border-color: var(--pmpro--color--accent--variation);
+			color: var(--pmpro--color--base);
+		}
+
+		&.pmpro_member_directory_pagination-current {
+			background-color: var(--pmpro--color--accent);
+			color: var(--pmpro--color--base);
+			cursor: default;
+			font-weight: 700;
+		}
+
+		&.pmpro_member_directory_pagination-previous {
+			margin-right: 0;
+		}
+	}
+
+}
+
+/* This is legacy pagination styling we can leave in here until we remove templating. */
 .pmpro_page_numbers a {
 	padding: 6px;
 }

--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -98,6 +98,40 @@ div.pmpro_member_profile strong {display: block; }
 		.pmpro_member_profile_field {
 			box-sizing: border-box;
 			flex: 1 1 calc(50% - var(--pmpro--base--spacing--medium));
+
+			&:has(iframe) {
+				flex-basis: 100%;
+				height: 0;
+				overflow: hidden;
+				padding-bottom: 56.25%;
+				position: relative;
+				width: 100%;
+
+				iframe {
+					height: 100%;
+					left: 0;
+					position: absolute;
+					top: 0;
+					width: 100%;
+				}
+			}
+
+			&:has(audio) {
+				flex-basis: 100%;
+
+				audio {
+					width: 100%;
+				}
+			}
+
+			&:has(video) {
+				flex-basis: 100%;
+
+				video {
+					width: 100%;
+				}
+			}
+
 		}
 
 		.pmpro_member_profile_field_label {
@@ -125,6 +159,23 @@ div.pmpro_member_profile strong {display: block; }
 	.pmpro_member_directory.pmpro_member_directory-3col,
 	.pmpro_member_directory.pmpro_member_directory-4col {
 		grid-template-columns: 1fr;
+	}
+}
+
+/**
+ * Special user field formatting.
+ */
+.pmpro_member_profile_field_data:has([class*="pmpro_form_field-file-subtype_"]) {
+
+	a {
+		align-items: center;
+		display: flex;
+		gap: var(--pmpro--base--spacing--small);
+
+		img {
+			max-height: 40px;
+			width: auto;
+		}
 	}
 }
 

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Deprecated hooks, filters and functions
+ *
+ * @since TBD
+ */
+
+/**
+ * Check for deprecated filters.
+ */
+function pmpromd_init_check_for_deprecated_filters() {
+	global $wp_filter;
+
+	// Deprecated filter name => new filter name (or null if there is no alternative).
+	$pmpromd_map_deprecated_filters = array(
+		'pmpro_member_profile_fields' => 'pmpro_member_profile_elements',
+	);
+	
+	foreach ( $pmpromd_map_deprecated_filters as $old => $new ) {
+		if ( has_filter( $old ) ) {
+			if ( ! empty( $new ) ) {
+				// We have an alternative filter. Let's show an error message and forward to that new filter.
+				/* translators: 1: the old hook name, 2: the new or replacement hook name */
+				trigger_error( esc_html( sprintf( esc_html__( 'The %1$s hook has been deprecated in the Member Directory Add On for Paid Memberships Pro. Please use the %2$s hook instead.', 'pmpro-member-directory' ), $old, $new ) ) );
+				
+				// Add filters back using the new tag.
+				foreach( $wp_filter[$old]->callbacks as $priority => $callbacks ) {
+					foreach( $callbacks as $callback ) {
+						add_filter( $new, $callback['function'], $priority, $callback['accepted_args'] ); 
+					}
+				}
+			} else {
+				// We don't have an alternative filter. Let's just show an error message.
+				/* translators: 1: the old hook name */
+				trigger_error( esc_html( sprintf( esc_html__( 'The %1$s hook has been deprecated in  Member Directory Add On for Paid Memberships Pro and may not be available in future versions.', 'pmpro-member-directory' ), $old ) ) );
+			}
+		}
+	}
+}
+add_action( 'init', 'pmpromd_init_check_for_deprecated_filters', 99 );

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -14,6 +14,7 @@ function pmpromd_init_check_for_deprecated_filters() {
 	// Deprecated filter name => new filter name (or null if there is no alternative).
 	$pmpromd_map_deprecated_filters = array(
 		'pmpro_member_profile_fields' => 'pmpro_member_profile_elements',
+		'pmpro_member_directory_fields' => 'pmpro_member_directory_elements',
 	);
 	
 	foreach ( $pmpromd_map_deprecated_filters as $old => $new ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -477,6 +477,30 @@ function pmpromd_get_display_value( $element, $pu ) {
 			case 'membership_enddate':
 				$value = $pu->membership_level->enddate;
 				break;
+			case 'pmpro_billing_address':
+				$value = pmpro_formatAddress(
+					trim( $pu->pmpro_bfirstname . ' ' . $pu->pmpro_blastname ),
+					$pu->pmpro_baddress1,
+					$pu->pmpro_baddress2,
+					$pu->pmpro_bcity,
+					$pu->pmpro_bstate,
+					$pu->pmpro_bzipcode,
+					$pu->pmpro_bcountry,
+					$pu->pmpro_bphone
+				);
+				break;
+			case 'pmpro_shipping_address':
+				$value = pmpro_formatAddress(
+					trim( $pu->pmpro_sfirstname . ' ' . $pu->pmpro_slastname ),
+					$pu->pmpro_saddress1,
+					$pu->pmpro_saddress2,
+					$pu->pmpro_scity,
+					$pu->pmpro_sstate,
+					$pu->pmpro_szipcode,
+					$pu->pmpro_scountry,
+					$pu->pmpro_sphone
+				);
+				break;
 		}
 
 		// If we still do not have a value, try usermeta.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -204,6 +204,11 @@ function pmpromd_build_profile_url( $pu, $profile_url = false, $separator = fals
  * Update the_title for the Profile page.
  */
 function pmpromd_the_title_profile_page( $title, $post_id = NULL ) {
+	// If we're in the admin, don't do anything.
+	if ( is_admin() ) {
+		return $title;
+	}
+
 	global $main_post_id, $current_user, $wp_query;
 	if( $post_id == $main_post_id ) {
 		$pu = pmpromd_get_user();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -377,7 +377,12 @@ function pmpromd_prepare_elements_array( $elements ) {
 		// Remove a trailing comma or semicolon if it exists.
 		$elements = rtrim( $elements, ',;' );
 
-		// Explode the elements string.
+		// Convert line breaks to semicolons (for the block editor).
+		if ( strpos( $elements, "\n" ) !== FALSE ) {
+			$elements = str_replace( "\n", ';', $elements );
+		}
+
+		// Build the elements array.
 		$elements = explode( ';', $elements );
 		foreach ( $elements as $element ) {
 			// Remove spaces from the beginning and end of the element.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -409,7 +409,7 @@ function pmpromd_prepare_elements_array( $elements ) {
 /**
  * Get the value of a specific element from a string of HTML.
  */
-function pmpromd_get_display_value( $element, $pu ) {
+function pmpromd_get_display_value( $element, $pu, $location = 'profile' ) {
 	// Is this a user field?
 	if ( class_exists( 'PMPro_Field_Group' ) ) {
 		$user_field = PMPro_Field_Group::get_field( $element[1] );
@@ -463,7 +463,10 @@ function pmpromd_get_display_value( $element, $pu ) {
 		// Additional formatting and special cases.
 		switch ( $element ) {
 			case 'display_name':
-				$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . pmpro_member_directory_get_member_display_name( $pu ) . '</h2>';
+				$value = pmpro_member_directory_get_member_display_name( $pu );
+				if ( $location == 'profile' ) {
+					$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . $value . '</h2>';
+				}
 				break;
 			case 'avatar':
 				$value = get_avatar( $pu->ID, $avatar_size, NULL, $pu->display_name );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -409,7 +409,7 @@ function pmpromd_prepare_elements_array( $elements ) {
 /**
  * Get the value of a specific element from a string of HTML.
  */
-function pmpromd_get_display_value( $element, $pu, $location = 'profile' ) {
+function pmpromd_get_display_value( $element, $pu ) {
 	// Is this a user field?
 	if ( class_exists( 'PMPro_Field_Group' ) ) {
 		$user_field = PMPro_Field_Group::get_field( $element[1] );
@@ -464,9 +464,6 @@ function pmpromd_get_display_value( $element, $pu, $location = 'profile' ) {
 		switch ( $element ) {
 			case 'display_name':
 				$value = pmpro_member_directory_get_member_display_name( $pu );
-				if ( $location == 'profile' ) {
-					$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . $value . '</h2>';
-				}
 				break;
 			case 'avatar':
 				$value = get_avatar( $pu->ID, $avatar_size, NULL, $pu->display_name );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -90,7 +90,7 @@ function pmpromd_get_user_by_identifier( $value ) {
  * @since 1.2.0
  *
  */
-function pmpromd_get_user( $user_id = false ){
+function pmpromd_get_user( $user_id = false ) {
 	global $wp_query, $current_user;
 
 	if ( $user_id ) {
@@ -198,4 +198,291 @@ function pmpromd_build_profile_url( $pu, $profile_url = false, $separator = fals
 	} else {
 		return $profile_url . sanitize_title( $pu );
 	}
+}
+
+/**
+ * Update the_title for the Profile page.
+ */
+function pmpromd_the_title_profile_page( $title, $post_id = NULL ) {
+	global $main_post_id, $current_user, $wp_query;
+	if( $post_id == $main_post_id ) {
+		$pu = pmpromd_get_user();
+
+		$display_name = pmpro_member_directory_get_member_display_name( $pu );
+
+		if( ! empty( $display_name ) ){
+			$title = $display_name;
+		}
+	}
+	return $title;
+}
+add_filter( 'the_title', 'pmpromd_the_title_profile_page', 10, 2 );
+
+/**
+ * Update the document title parts for the Profile page.
+ */
+function pmpromd_document_title_parts( $title_parts ) {
+	global $wpdb, $main_post_id, $post, $current_user, $wp_query;
+
+	if ( isset( $post->ID ) && $post->ID == $main_post_id ) {
+
+		$pu = pmpromd_get_user();
+
+		$display_name = pmpro_member_directory_get_member_display_name( $pu );
+
+		if ( ! empty( $display_name ) ) {
+			$title_parts['title'] = $display_name; // Set the main title part.
+		}
+	}
+
+	return $title_parts;
+}
+add_filter( 'document_title_parts', 'pmpromd_document_title_parts' );
+
+/**
+ * We're working with the menu now so remove the filters.
+ *
+ * @since TBD
+ *
+ * @param string|null $output Nav menu output to short-circuit with. Default null.
+ *
+ * @return string|null Nav menu output to short-circuit with. Default null.
+ */
+function pmpromd_remove_title_filters_in_menus( $nav_menu ) {
+	// Before we work with the menu, remove the title filter.
+	remove_filter( 'the_title', 'pmpromd_the_title_profile_page', 10, 2 );
+
+	// Remove the `pmpromd_wp_title` filter.
+	// This is no longer used in the Add On but may be present in legacy custom templates.
+	remove_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
+    return $nav_menu;
+}
+add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_title_filters_in_menus' );
+
+/**
+ * We're done working with the menu so add those filters back.
+ *
+ * @since TBD
+ *
+ * @param string $items The HTML list content for the menu items.
+ *
+ * @return string The HTML list content for the menu items.
+ */
+function pmpromd_readd_title_filters_in_menus( $items ) {
+    // We are done working with menu, so add the title filter back.
+    add_filter( 'the_title', 'pmpromd_the_title_profile_page', 10, 2 );
+
+	// Add the `pmpromd_wp_title` filter back.
+	// This is no longer used in the Add On but may be present in legacy custom templates.
+	add_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
+    return $items;
+}
+add_filter( 'wp_nav_menu_items', 'pmpromd_readd_title_filters_in_menus' );
+
+/**
+ * Preheader operations for the profile page.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmpromd_profile_page_preheader() {
+	global $post, $pmpro_pages, $current_user;
+
+	// Bail if we're not on the profile page.
+	if ( empty( $pmpro_pages['profile'] ) || ! is_page( $pmpro_pages['profile'] ) ) {
+		return;
+	}
+
+	/**
+	 * Preheader operations here.
+	 */
+	global $main_post_id;
+	$main_post_id = $post->ID;
+
+	// Get the profile user.
+	$pu = pmpromd_get_user();
+
+	// If we are going to redirect, set the page to redirect to.
+	if ( ! empty( $pmpro_pages['directory'] ) ) {
+		$redirect = get_permalink( $pmpro_pages['directory'] );
+	} else {
+		$redirect = home_url();
+	}
+
+	// Is this user hidden from directory?
+	if ( ! empty( $pu ) ) {
+		$pmpromd_hide_directory = get_user_meta( $pu->ID, 'pmpromd_hide_directory', true );
+	} else {
+		$pmpromd_hide_directory = false;
+	}
+
+	// If no profile user, membership level, or hidden, go to directory or home.
+	if ( empty( $pu ) || empty( $pu->ID ) || ! pmpro_hasMembershipLevel( null, $pu->ID ) || $pmpromd_hide_directory == '1' ) {
+		wp_redirect( $redirect );
+		exit;
+	}
+
+	// Integrate with Approvals Add On.
+	if ( class_exists( 'PMPro_Approvals' ) ){
+		// Check that the user has a membership level that does not require approval
+		// or that the user has a membership level that does require approval and has been approved.
+		$user_levels = pmpro_getMembershipLevelsForUser( $pu->ID );
+		$approval_levels = PMPro_Approvals::getApprovalLevels();
+		$okay = false;
+		foreach ( $user_levels as $level ) {
+			if ( ! in_array( $level->id, $approval_levels ) || PMPro_Approvals::isApproved( $pu->ID, $level->id ) ) {
+				$okay = true;
+				break;
+			}
+		}
+
+		if ( ! $okay ) {
+			wp_redirect( $redirect );
+			exit;
+		}
+	}
+
+	/**
+	 * If a level is required for the profile page, make sure the profile user has it.
+	 */
+
+	// Check to see if the page's content is restricted by shortcode, if so we don't have to redirect away.
+	if ( has_shortcode( $post->post_content, 'membership' ) || has_block( 'pmpro/membership', $post->post_content ) ) {
+		return;
+	}
+
+	// Check if levels are required within the profile's shortcode.
+	// If they don't have that level, redirect away.
+	$levels = pmpro_getMatches( "/ levels?=[\"']([^\"^']*)[\"']/", $post->post_content, true );
+	if ( ! empty( $levels ) && ! pmpro_hasMembershipLevel( explode( ",", $levels ), $pu->ID ) ) {
+		wp_redirect( $redirect );
+		exit;
+	}
+}
+add_action( 'wp', 'pmpromd_profile_page_preheader', 1 );
+
+/**
+ * Prepare the elements attribute of the shortcodes.
+ */
+function pmpromd_prepare_elements_array( $elements ) {
+	// Initialize the elements array.
+	$elements_array = array();
+
+	if ( ! empty( $elements ) ) {
+		// Remove a trailing comma or semicolon if it exists.
+		$elements = rtrim( $elements, ',;' );
+
+		// Explode the elements string.
+		$elements = explode( ';', $elements );
+		foreach ( $elements as $element ) {
+			// Remove spaces from the beginning and end of the element.
+			$element = trim( $element );
+
+			// Check if the element is empty.
+			if ( empty( $element ) ) {
+				continue;
+			}
+
+			if ( str_contains( $element, ',' ) ) {
+				// If there is a comma, then we know it has label/field pair.
+				$elements_array[] = array_map( 'trim', explode( ',', $element ) );
+			} else {
+				// Otherwise we have just the field with no label.
+				$elements_array[] = array( '', trim( $element ) );
+			}
+		}
+	}
+
+	return $elements_array;
+}
+
+/**
+ * Get the value of a specific element from a string of HTML.
+ */
+function pmpromd_get_display_value( $element, $pu ) {
+	// Is this a user field?
+	if ( class_exists( 'PMPro_Field_Group' ) ) {
+		$user_field = PMPro_Field_Group::get_field( $element[1] );
+	} else {
+		$user_field = pmpro_get_user_field( $element[1] );
+	}
+
+	// Yes, this is a user field. Check that the user has the required level for this field.
+	if ( ! empty( $user_field ) ) {
+		if ( ! empty( $user_field->levels ) && ! pmpro_hasMembershipLevel( $user_field->levels, $pu->ID ) ) {
+			// The user does not have the required level for this field.
+			return '';
+		}
+		$value = $pu->{$element[1]};
+		return $user_field->displayValue( $value, false );
+	} else {
+		// Let's try to get the value from other places and format it for return.
+
+		// Get a list of fields related to the user's level.
+		$pmpro_level_fields = array(
+			'membership_name',
+			'membership_startdate',
+			'membership_enddate',
+		);
+
+		// Get a list of fields that should be formatted as dates.
+		$date_fields = array(
+			'membership_startdate',
+			'membership_enddate',
+			'user_registered',
+		);
+
+		// Check if the $element is a PMPro level field.
+		if ( in_array( $element, $pmpro_level_fields ) ) {
+			$pu->membership_level = pmpro_getMembershipLevelForUser( $pu->ID );
+			$allmylevels = pmpro_getMembershipLevelsForUser( $pu->ID );
+			$membership_levels = array();
+			foreach ( $allmylevels as $curlevel ) {
+				$membership_levels[] = $curlevel->name;
+			}
+			$pu->membership_levels = implode(', ', $membership_levels);		
+		}
+
+		// Additional formatting and special cases.
+		switch ( $element ) {
+			case 'display_name':
+				$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . pmpro_member_directory_get_member_display_name( $pu ) . '</h2>';
+				break;
+			case 'avatar':
+				/**
+				 * Filter the size of the avatar displayed in the member directory.
+				 *
+				 * @since TBD
+				 * @param int $avatar_size The size of the avatar in pixels.
+				 * @param string $page The page where the avatar is being displayed.
+				 *
+				 * @return int The size of the avatar in pixels.
+				 */
+				$avatar_size = apply_filters( 'pmpro_member_directory_avatar_size', 128, $page );
+				$value = get_avatar( $pu->ID, $avatar_size, NULL, $pu->display_name );
+				break;
+			case 'membership_name':
+				$value = $pu->membership_levels;
+				break;
+			case 'membership_startdate':
+				$value = $pu->membership_level->startdate;
+				break;
+			case 'membership_enddate':
+				$value = $pu->membership_level->enddate;
+				break;
+		}
+
+		// If we still do not have a value, try usermeta.
+		if ( empty( $value ) ) {
+			$value = $pu->$element;
+		}
+
+		// Format the date fields.
+		if ( in_array( $element, $date_fields ) && ! empty( $value ) ) {
+			$value = date_i18n( get_option('date_format'), $value );
+		}
+
+	}
+
+	return $value;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -443,22 +443,19 @@ function pmpromd_get_display_value( $element, $pu ) {
 			$pu->membership_levels = implode(', ', $membership_levels);		
 		}
 
+		// Get the avatar_size for the avatar element.
+		if ( str_contains( $element, 'avatar' ) ) {
+			$element_parts = explode( '|', $element );
+			$element = $element_parts[0];
+			$avatar_size = ! empty( $element_parts[1] ) ? $element_parts[1] : 128;
+		}
+
 		// Additional formatting and special cases.
 		switch ( $element ) {
 			case 'display_name':
 				$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . pmpro_member_directory_get_member_display_name( $pu ) . '</h2>';
 				break;
 			case 'avatar':
-				/**
-				 * Filter the size of the avatar displayed in the member directory.
-				 *
-				 * @since TBD
-				 * @param int $avatar_size The size of the avatar in pixels.
-				 * @param string $page The page where the avatar is being displayed.
-				 *
-				 * @return int The size of the avatar in pixels.
-				 */
-				$avatar_size = apply_filters( 'pmpro_member_directory_avatar_size', 128, $page );
 				$value = get_avatar( $pu->ID, $avatar_size, NULL, $pu->display_name );
 				break;
 			case 'membership_name':

--- a/includes/search.php
+++ b/includes/search.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Function to display the search form for the member directory.
+ *
+ * @since TBD
+ * @return string $content The search form for the member directory.
+ */
+function pmpromd_search_form() {
+	global $pmpro_pages;
+
+	// Get the directory page URL.
+	$directory_url = ! empty( $pmpro_pages['directory'] ) ? get_permalink( $pmpro_pages['directory'] ) : '';
+
+	// Get the limit for the search results.
+	$limit = ! empty( $_REQUEST['limit'] ) ? intval( $_REQUEST['limit'] ) : 10;
+	?>
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
+		<form action="<?php echo esc_url( $directory_url ); ?>" method="post" role="search" class="<?php echo pmpro_get_element_class( 'pmpro_form pmpro_member_directory_search', 'pmpro_member_directory_search' ); ?>">
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-ps', 'pmpro_form_field-ps' ) ); ?>">
+					<label for="ps" class="screen-reader-text"><?php _e('Search for:','pmpro-member-directory'); ?></label>
+					<input type="search" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text' ) ); ?>" placeholder="<?php esc_attr_e( 'Search Members','pmpro-member-directory' ); ?>" name="ps" id="ps" value="<?php if(!empty($_REQUEST['ps'])) echo esc_attr($_REQUEST['ps']);?>" title="<?php esc_attr_e('Search Members','pmpro-member-directory'); ?>" />
+					<input type="hidden" name="limit" value="<?php echo esc_attr($limit);?>" />
+				</div> <!-- end pmpro_form_field-ps -->
+			</div> <!-- end pmpro_form_fields -->
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
+				<input type="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn' ) ); ?>" value="<?php esc_attr_e( 'Submit','pmpro-member-directory'); ?>">
+			</div>
+		</form>
+	</div> <!-- end pmpro -->
+	<?php
+}

--- a/includes/search.php
+++ b/includes/search.php
@@ -14,19 +14,17 @@ function pmpromd_search_form() {
 	// Get the limit for the search results.
 	$limit = ! empty( $_REQUEST['limit'] ) ? intval( $_REQUEST['limit'] ) : 10;
 	?>
-	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
-		<form action="<?php echo esc_url( $directory_url ); ?>" method="post" role="search" class="<?php echo pmpro_get_element_class( 'pmpro_form pmpro_member_directory_search', 'pmpro_member_directory_search' ); ?>">
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
-				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-ps', 'pmpro_form_field-ps' ) ); ?>">
-					<label for="ps" class="screen-reader-text"><?php _e('Search for:','pmpro-member-directory'); ?></label>
-					<input type="search" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text' ) ); ?>" placeholder="<?php esc_attr_e( 'Search Members','pmpro-member-directory' ); ?>" name="ps" id="ps" value="<?php if(!empty($_REQUEST['ps'])) echo esc_attr($_REQUEST['ps']);?>" title="<?php esc_attr_e('Search Members','pmpro-member-directory'); ?>" />
-					<input type="hidden" name="limit" value="<?php echo esc_attr($limit);?>" />
-				</div> <!-- end pmpro_form_field-ps -->
-			</div> <!-- end pmpro_form_fields -->
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
-				<input type="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn' ) ); ?>" value="<?php esc_attr_e( 'Submit','pmpro-member-directory'); ?>">
-			</div>
-		</form>
-	</div> <!-- end pmpro -->
+	<form action="<?php echo esc_url( $directory_url ); ?>" method="post" role="search" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form pmpro_member_directory_search', 'pmpro_member_directory_search' ) ); ?>">
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-ps', 'pmpro_form_field-ps' ) ); ?>">
+				<label for="ps" class="screen-reader-text"><?php _e('Search for:','pmpro-member-directory'); ?></label>
+				<input type="search" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text' ) ); ?>" placeholder="<?php esc_attr_e( 'Search Members','pmpro-member-directory' ); ?>" name="ps" id="ps" value="<?php if(!empty($_REQUEST['ps'])) echo esc_attr($_REQUEST['ps']);?>" title="<?php esc_attr_e('Search Members','pmpro-member-directory'); ?>" />
+				<input type="hidden" name="limit" value="<?php echo esc_attr($limit);?>" />
+			</div> <!-- end pmpro_form_field-ps -->
+		</div> <!-- end pmpro_form_fields -->
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
+			<input type="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn' ) ); ?>" value="<?php esc_attr_e( 'Submit','pmpro-member-directory'); ?>">
+		</div>
+	</form>
 	<?php
 }

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -29,7 +29,12 @@ file_exists( $custom_profile_file ) ? require_once( $custom_profile_file ) : req
 // Includes
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/blocks/blocks.php');
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/admin.php' );
+require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/deprecated.php' );
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/functions.php' );
+require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/search.php' );
+
+// Shortcodes
+require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/shortcodes/search.php' );
 
 /**
  * Load the languages folder for translations.

--- a/shortcodes/search.php
+++ b/shortcodes/search.php
@@ -3,6 +3,15 @@
  * Show the content for the [pmpro_member_directory_search] shortcode.
  */
 function pmpromd_search_shortcode() {
-	echo pmpromd_search_form();
+	ob_start();
+	?>
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
+		<?php pmpromd_search_form(); ?>
+	</div>
+	<?php
+	$content = ob_get_contents();
+	ob_end_clean();
+
+	return $content;
 }
 add_shortcode( 'pmpro_member_directory_search', 'pmpromd_search_shortcode' );

--- a/shortcodes/search.php
+++ b/shortcodes/search.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Show the content for the [pmpro_member_directory_search] shortcode.
+ */
+function pmpromd_search_shortcode() {
+	echo pmpromd_search_form();
+}
+add_shortcode( 'pmpro_member_directory_search', 'pmpromd_search_shortcode' );

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -260,6 +260,9 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 				'fields_array' => $elements_array, // Backwards compatibility. We can remove this in a future version.
 			) );
 
+			// Set the displayed_levels variable to use for displaying values.
+			$displayed_levels = empty( $levels ) ? 'all' : $levels;
+
 			do_action( 'pmpro_member_directory_before', $sqlQuery, $shortcode_atts );
 		?>
 
@@ -289,7 +292,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 										<tr id="pmpro_member_directory_row-<?php echo esc_attr( $auser->ID ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_row' ) ); ?>">
 											<?php
 												foreach ( $elements_array as $element ) {
-													$value = pmpromd_get_display_value( $element[1], $auser );
+													$value = pmpromd_get_display_value( $element[1], $auser, $displayed_levels );
 													// Wrap the value in a link if the element is in the linked elements array.
 													if ( ! empty( $link ) && in_array( $element[1], $linked_elements ) ) {
 														$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';
@@ -328,7 +331,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 							<?php
 								// Loop through the elements and output the content.
 								foreach ( $elements_array as $element ) {
-									$value = pmpromd_get_display_value( $element[1], $auser );
+									$value = pmpromd_get_display_value( $element[1], $auser, $displayed_levels );
 									if ( ! empty( $value ) ) {
 										// Wrap the value in a link if the element is in the linked elements array.
 										if ( ! empty( $link ) && in_array( $element[1], $linked_elements ) ) {

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -225,36 +225,43 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 			* @return array $elements_array The array of elements to display on the member directory.
 			*/
 			$elements_array = apply_filters( 'pmpro_member_directory_elements', $elements_array );
+
+			// Set up an array of items that will be linked to the user's profile.
+			$linked_elements = array( 'display_name' );
+			foreach ( $elements_array as $element ) {
+				if ( strpos( $element[1], 'avatar|' ) !== false ) {
+					$linked_elements[] = $element[1];
+				}
+			}
+
+			/**
+			 * Filter to override the attributes passed into the shortcode.
+			 *
+			 * @param array Contains all of the shortcode attributes used in the directory shortcode
+			 */
+			$shortcode_atts = apply_filters( 'pmpro_member_directory_before_atts', array(
+				'avatar_size' => $avatar_size,
+				'elements' => $elements,
+				'fields' => $fields,
+				'layout' => $layout,
+				'level' => $level,
+				'levels' => $levels,
+				'limit' => $limit,
+				'link' => $link,
+				'order_by' => $order_by,
+				'order' => $order,
+				'show_avatar' => $show_avatar,
+				'show_email' => $show_email,
+				'show_level' => $show_level,
+				'show_search' => $show_search,
+				'show_startdate' => $show_startdate,
+				'avatar_align' => $avatar_align,
+				'elements_array' => $elements_array,
+				'fields_array' => $elements_array, // Backwards compatibility. We can remove this in a future version.
+			) );
+
+			do_action( 'pmpro_member_directory_before', $sqlQuery, $shortcode_atts );
 		?>
-
-		<?php
-		/**
-		 * Filter to override the attributes passed into the shortcode.
-		 *
-		 * @param array Contains all of the shortcode attributes used in the directory shortcode
-		 */
-		$shortcode_atts = apply_filters( 'pmpro_member_directory_before_atts', array(
-			'avatar_size' => $avatar_size,
-			'elements' => $elements,
-			'fields' => $fields,
-			'layout' => $layout,
-			'level' => $level,
-			'levels' => $levels,
-			'limit' => $limit,
-			'link' => $link,
-			'order_by' => $order_by,
-			'order' => $order,
-			'show_avatar' => $show_avatar,
-			'show_email' => $show_email,
-			'show_level' => $show_level,
-			'show_search' => $show_search,
-			'show_startdate' => $show_startdate,
-			'avatar_align' => $avatar_align,
-			'elements_array' => $elements_array,
-			'fields_array' => $elements_array, // Backwards compatibility. We can remove this in a future version.
-		) );
-
-		do_action( 'pmpro_member_directory_before', $sqlQuery, $shortcode_atts ); ?>
 
 		<div class="pmpro_member_directory<?php echo ( ! empty( $layout ) ? ' pmpro_member_directory-' . esc_attr( $layout ) : '' ); ?>">
 			<?php
@@ -282,7 +289,11 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 										<tr id="pmpro_member_directory_row-<?php echo esc_attr( $auser->ID ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_row' ) ); ?>">
 											<?php
 												foreach ( $elements_array as $element ) {
-													$value = pmpromd_get_display_value( $element[1], $auser, 'directory' );
+													$value = pmpromd_get_display_value( $element[1], $auser );
+													// Wrap the value in a link if the element is in the linked elements array.
+													if ( ! empty( $link ) && in_array( $element[1], $linked_elements ) ) {
+														$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';
+													}
 													?>
 													<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_' . $element[1] ) ); ?>"<?php echo ! empty( $element[0] ) ? ' data-title="' . esc_attr( $element[0] ) . '"' : ''; ?>>
 														<?php echo $value; ?>
@@ -317,8 +328,12 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 							<?php
 								// Loop through the elements and output the content.
 								foreach ( $elements_array as $element ) {
-									$value = pmpromd_get_display_value( $element[1], $auser, 'directory' );
+									$value = pmpromd_get_display_value( $element[1], $auser );
 									if ( ! empty( $value ) ) {
+										// Wrap the value in a link if the element is in the linked elements array.
+										if ( ! empty( $link ) && in_array( $element[1], $linked_elements ) ) {
+											$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';
+										}
 										?>
 										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . $element[1] ) ); ?>">
 											<?php if ( ! empty( $element[0] ) ) { ?>

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -295,7 +295,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 														$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';
 													}
 													?>
-													<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_' . $element[1] ) ); ?>"<?php echo ! empty( $element[0] ) ? ' data-title="' . esc_attr( $element[0] ) . '"' : ''; ?>>
+													<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_field-' . strtok( $element[1], '|' ) ) ); ?>"<?php echo ! empty( $element[0] ) ? ' data-title="' . esc_attr( $element[0] ) . '"' : ''; ?>>
 														<?php echo $value; ?>
 													</td>
 													<?php
@@ -334,8 +334,11 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 										if ( ! empty( $link ) && in_array( $element[1], $linked_elements ) ) {
 											$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';
 										}
+										if ( 'display_name' === $element[1] ) {
+											$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-large' ) . '">' . $value . '</h2>';
+										}
 										?>
-										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . $element[1] ) ); ?>">
+										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . strtok( $element[1], '|' ) ) ); ?>">
 											<?php if ( ! empty( $element[0] ) ) { ?>
 												<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field_label' ) ); ?>">
 													<?php echo esc_html( $element[0] ); ?>
@@ -377,7 +380,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 			do_action( 'pmpro_member_directory_after', $sqlQuery, $shortcode_atts );
 		?>
 
-		<div class="pmpro_pagination">
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_pagination' ) ); ?>">
 			<?php
 			//prev
 			if ( $pn > 1 ) {
@@ -388,39 +391,39 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 				);
 				$query_args = apply_filters( 'pmpromd_pagination_url', $query_args, 'prev' );
 				?>
-				<span class="pmpro_prev"><a href="<?php echo esc_url(add_query_arg( $query_args, get_permalink($post->ID)));?>">&laquo; <?php _e('Previous','pmpro-member-directory'); ?></a></span>
+				<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_pagination-previous' ) ); ?>" href="<?php echo esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) );?>" title="<?php esc_attr_e( 'Previous Page', 'pmpro-member-directory' ); ?>"><?php esc_html_e( '&larr; Previous', 'pmpro-member-directory' ); ?></a>
 				<?php
 			}
 
 			$number_of_pages = $totalrows / $limit;
 			//Page Numbers
-			?>
-			<span class="pmpro_page_numbers">
-				<?php
-					$counter = 0;
-					if ( empty( $pn ) || $pn != 1 ) {
-						echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" title="' . esc_attr__( 'Previous', 'pmpromd' ) . '">...</a>';
-					}
+			$counter = 0;
+			if ( empty( $pn ) || $pn != 1 ) {
+				echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" title="' . esc_attr__( 'Previous', 'pmpromd' ) . '">...</a>';
+			}
 
-					if ( round( $number_of_pages, 0 ) !== 1 && $pn !== 1 ) {
-						//If there's only one page, no need to show the page numbers
-						for( $i = $pn; $i <= $number_of_pages; $i++ ){
-							if( $counter <= 6 ){
-								$query_args = array(
-									'ps' => $s,
-									'pn' => $i,
-									'limit' => $limit,
-								);
+			if ( round( $number_of_pages, 0 ) !== 1 && $pn !== 1 ) {
+				//If there's only one page, no need to show the page numbers
+				for( $i = $pn; $i <= $number_of_pages; $i++ ){
+					if( $counter <= 6 ){
+						$query_args = array(
+							'ps' => $s,
+							'pn' => $i,
+							'limit' => $limit,
+						);
 
-								if( $i == $pn ){ $active_class = 'class="pmpro_page_active"'; } else { $active_class = ''; }
-
-								echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" ' . $active_class . ' title="' . esc_attr( sprintf( __('Page %s', 'pmpromd' ), $i ) ) . '">' . $i . '</a>';
-							}
-							$counter++;
+						$classes = array();
+						$classes[] = 'pmpro_member_directory_pagination-page';
+						if ( $i == $pn ) {
+							$classes[] = 'pmpro_member_directory_pagination-current';
 						}
+						$classes = implode(	' ', $classes );
+						echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" class="' . esc_attr( pmpro_get_element_class( $classes ) ) . '" title="' . esc_attr( sprintf( __('Page %s', 'pmpro-member-directory' ), $i ) ) . '">' . $i . '</a>';
 					}
-				?>
-			</span> <!-- end pmpro_page_numbers -->
+					$counter++;
+				}
+			}
+			?>
 
 			<?php
 			//next
@@ -432,7 +435,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 				);
 				$query_args = apply_filters( 'pmpromd_pagination_url', $query_args, 'next' );
 				?>
-				<span class="pmpro_next"><a href="<?php echo esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) );?>"><?php _e( 'Next', 'pmpro-member-directory' ); ?> &raquo;</a></span>
+				<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_pagination-next' ) ); ?>" href="<?php echo esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) );?>" title="<?php esc_attr_e( 'Next Page', 'pmpro-member-directory' ); ?>"><?php esc_html_e( 'Next &rarr;', 'pmpro-member-directory' ); ?></a>
 				<?php
 			}
 			?>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -1,169 +1,11 @@
 <?php
-/*
-	This shortcode will display the profile for the user ID specified in the URL and additional content based on the defined attributes.
-*/
-function pmpromd_profile_preheader()
-{
-	global $post, $pmpro_pages, $current_user;
-
-	// Bail if we're not on the profile page.
-	if ( empty( $pmpro_pages['profile'] ) || ! is_page( $pmpro_pages['profile'] ) ) {
-		return;
-	}
-		
-	/*
-		Preheader operations here.
-	*/
-	global $main_post_id;
-	$main_post_id = $post->ID;
-
-	$pu = pmpromd_get_user();
-
-	// Is this user hidden from directory?
-	if ( ! empty( $pu ) ) {
-		$pmpromd_hide_directory = get_user_meta( $pu->ID, 'pmpromd_hide_directory', true );
-	} else {
-		$pmpromd_hide_directory = false;
-	}
-
-	// If no profile user, membership level, or hidden, go to directory or home.
-	if(empty($pu) || empty($pu->ID) || !pmpro_hasMembershipLevel(null, $pu->ID) || $pmpromd_hide_directory == '1' ) {
-		if(!empty($pmpro_pages['directory']))
-	 		wp_redirect(get_permalink($pmpro_pages['directory']));
-	 	else
-	 		wp_redirect(home_url());
-	 	exit;
-	}
-
-	// Integrate with Approvals.
-	if ( class_exists( 'PMPro_Approvals' ) ){
-		// Check that either the user has a membership level that does not require approval
-		// or that the user has a membership level that does require approval and has been approved.
-		$user_levels = pmpro_getMembershipLevelsForUser( $pu->ID );
-		$approval_levels = PMPro_Approvals::getApprovalLevels();
-		$okay = false;
-		foreach ( $user_levels as $level ) {
-			if ( ! in_array( $level->id, $approval_levels ) || PMPro_Approvals::isApproved( $pu->ID, $level->id ) ) {
-				$okay = true;
-				break;
-			}
-		}
-
-		if ( ! $okay ) {
-			if ( ! empty( $pmpro_pages['directory'] ) ) {
-				wp_redirect( get_permalink( $pmpro_pages['directory'] ) );
-			} else {
-				wp_redirect(home_url());
-				exit;
-			}
-		}
-	}
-
-	/*
-		If a level is required for the profile page, make sure the profile user has it.
-	*/
-
-	// Check to see if the page's content is restricted by shortcode, if so we don't have to redirect away.
-	if ( has_shortcode( $post->post_content, 'membership' ) || has_block( 'pmpro/membership', $post->post_content ) ) {
-		return;
-	}
-
-	//check is levels are required within the profile's shortcode, if they don't have that level redirect away.
-	$levels = pmpro_getMatches("/ levels?=[\"']([^\"^']*)[\"']/", $post->post_content, true);
-	if(!empty($levels) && !pmpro_hasMembershipLevel(explode(",", $levels), $pu->ID))
-	{
-		if(!empty($pmpro_pages['directory']))
-			wp_redirect(get_permalink($pmpro_pages['directory']));
-		else
-			wp_redirect(home_url());
-		exit;
-	}
-}
-add_action("wp", "pmpromd_profile_preheader", 1);
-
-/*
-	Update the head title and H1
-*/
-function pmpromd_the_title($title, $post_id = NULL)
-{
-	global $main_post_id, $current_user, $wp_query;
-	if( $post_id == $main_post_id ) {
-		$pu = pmpromd_get_user();
-
-		$display_name = pmpro_member_directory_get_member_display_name( $pu );
-
-		if( !empty( $display_name ) ){
-			$title = $display_name;
-		}
-	}
-	return $title;
-}
-add_filter("the_title", "pmpromd_the_title", 10, 2);
-
-function pmpromd_wp_title($title, $sep)
-{
-	global $wpdb, $main_post_id, $post, $current_user, $wp_query;
-	if( $post->ID == $main_post_id ) {
-
-		$pu = pmpromd_get_user();
-
-		$display_name = pmpro_member_directory_get_member_display_name( $pu );
-
-		if( !empty( $display_name ) ) {
-			$title = $display_name . ' ' . $sep . ' ';
-		}
-
-		$title .= get_bloginfo( 'name' );
-	}
-	return $title;
-}
-add_filter("wp_title", "pmpromd_wp_title", 10, 2);
-
 /**
- * We're working with the menu now so remove the filters.
- *
- * @since TBD
- *
- * @param string|null $output Nav menu output to short-circuit with. Default null.
- *
- * @return string|null Nav menu output to short-circuit with. Default null.
+ * Show the content for the [pmpro_member_profile] shortcode.
  */
-function pmpromd_remove_filters_menu_title( $nav_menu ) {	
-
-    remove_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
-    remove_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
-    return $nav_menu;
-}
-add_filter( 'pre_wp_nav_menu', 'pmpromd_remove_filters_menu_title' );
-
-
-/**
- * We're done working with the menu so add those filters back.
- *
- * @since TBD
- *
- * @param string $items The HTML list content for the menu items.
- *
- * @return string The HTML list content for the menu items.
- */
-function pmpromd_readd_filters_menu_title( $items ) {
-
-    // we are done working with menu, so add the title filter back
-    add_filter( 'wp_title', 'pmpromd_wp_title', 10, 2 );
-    add_filter( 'the_title', 'pmpromd_the_title', 10, 2 );
-    return $items;
-}
-add_filter( 'wp_nav_menu_items', 'pmpromd_readd_filters_menu_title' );
-
-function pmpromd_profile_shortcode($atts, $content=null, $code="")
-{
-	// $atts    ::= array of attributes
-	// $content ::= text within enclosing form of shortcode element
-	// $code    ::= the shortcode found, when == callback name
-	// examples: [pmpro_member_profile avatar="false" email="false"]
-
+function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 	extract(shortcode_atts(array(
 		'avatar_size' => '128',
+		'elements' => NULL,
 		'fields' => NULL,
 		'show_avatar' => true,
 		'show_bio' => true,
@@ -177,343 +19,190 @@ function pmpromd_profile_shortcode($atts, $content=null, $code="")
 		'user_id' => NULL
 	), $atts));
 
-	global $current_user, $display_name, $wpdb, $pmpro_pages, $pmprorh_registration_fields, $wp_query;
+	global $current_user, $pmpro_pages;
 
-	//some page vars
-	if(!empty($pmpro_pages['directory']))
-		$directory_url = get_permalink($pmpro_pages['directory']);
-	else
-		$directory_url = "";
-	if(!empty($pmpro_pages['profile']))
-		$profile_url = get_permalink($pmpro_pages['profile']);
+	// Get the directory and profile page URLs.
+	$directory_url = ! empty( $pmpro_pages['directory'] ) ? get_permalink( $pmpro_pages['directory'] ) : '';
+	$profile_url = ! empty( $pmpro_pages['profile'] ) ? get_permalink( $pmpro_pages['profile'] ) : '';
 
-	//turn 0's into falses
-	if($show_avatar === "0" || $show_avatar === "false" || $show_avatar === "no" || $show_avatar === false )
-		$show_avatar = false;
-	else
-		$show_avatar = true;
+	// Get the user for this profile.
+	$pu = pmpromd_get_user( $user_id );
 
-	if($show_billing === "0" || $show_billing === "false" || $show_billing === "no" || $show_billing === false )
-		$show_billing = false;
-	else
-		$show_billing = true;
+	// Validate boolean variables.
+	$show_avatar = filter_var( $show_avatar, FILTER_VALIDATE_BOOLEAN );
+	$show_billing = filter_var( $show_billing, FILTER_VALIDATE_BOOLEAN );
+	$show_bio = filter_var( $show_bio, FILTER_VALIDATE_BOOLEAN );
+	$show_email = filter_var( $show_email, FILTER_VALIDATE_BOOLEAN );
+	$show_level = filter_var( $show_level, FILTER_VALIDATE_BOOLEAN );
+	$show_name = filter_var( $show_name, FILTER_VALIDATE_BOOLEAN );
+	$show_phone = filter_var( $show_phone, FILTER_VALIDATE_BOOLEAN );
+	$show_search = filter_var( $show_search, FILTER_VALIDATE_BOOLEAN );
+	$show_startdate = filter_var( $show_startdate, FILTER_VALIDATE_BOOLEAN );
 
-	if($show_bio === "0" || $show_bio === "false" || $show_bio === "no" || $show_bio === false )
-		$show_bio = false;
-	else
-		$show_bio = true;
+	// Build our elements array. If we have an elements attribute on the shortcode, use that and ignore any other legacy attributes.
+	if ( ! empty( $elements ) ) {
+		$elements_array = pmpromd_prepare_elements_array( $elements );
+	} else {
+		// We need to support the legacy attributes for backwards compatibility.
+		$elements = '';
+		if ( ! empty( $show_name ) ) {
+			$elements .= 'display_name;';
+		}
+		if ( ! empty( $show_avatar ) ) {
+			if ( ! empty( $avatar_size ) ) {
+				$elements .= 'avatar|' . $avatar_size . ';';
+			} else {
+				$elements .= 'avatar;';
+			}
+		}
+		if ( ! empty( $show_bio ) ) {
+			$elements .= __( 'Biographical Info', 'pmpro-member-directory' ) . ',description;';
+		}
+		if ( ! empty( $show_email ) ) {
+			$elements .= __( 'Email Address', 'pmpro-member-directory' ) . ', user_email;';
+		}
+		// These are the fields that are not part of the user object and need special handling.
+		if ( ! empty( $show_level ) ) {
+			$elements .= __( 'Level', 'pmpro-member-directory' ) . ',membership_name;';
+		}
+		if ( ! empty( $show_startdate ) ) {
+			$elements .= __( 'Start Date', 'pmpro-member-directory' ) . ',membership_startdate;';
+		}
+		if ( ! empty( $show_billing ) ) {
+			$elements .= __( 'Address', 'pmpro-member-directory' ) . ',pmpro_baddress1|pmpro_baddress2|pmpro_bcity|pmpro_bstate|pmpro_bzipcode|pmpro_bcountry;';
+		}
+		if ( ! empty( $show_phone ) ) {
+			$elements .= __( 'Phone Number', 'pmpro-member-directory' ) . ',pmpro_bphone;';
+		}
+		if ( ! empty( $fields ) ) {
+			$elements .= $fields;
+		}
+		$elements_array = pmpromd_prepare_elements_array( $elements );
+	}
 
-	if($show_email === "0" || $show_email === "false" || $show_email === "no" || $show_email === false )
-		$show_email = false;
-	else
-		$show_email = true;
-
-	if($show_level === "0" || $show_level === "false" || $show_level === "no" || $show_level === false )
-		$show_level = false;
-	else
-		$show_level = true;
-
-	if($show_name === "0" || $show_name === "false" || $show_name === "no" || $show_name === false )
-		$show_name = false;
-	else
-		$show_name = true;
-
-	if($show_phone === "0" || $show_phone === "false" || $show_phone === "no" || $show_phone === false )
-		$show_phone = false;
-	else
-		$show_phone = true;
-
-	if($show_search === "0" || $show_search === "false" || $show_search === "no" || $show_search === false )
-		$show_search = false;
-	else
-		$show_search = true;
-
-	if($show_startdate === "0" || $show_startdate === "false" || $show_startdate === "no" || $show_startdate === false )
-		$show_startdate = false;
-	else
-		$show_startdate = true;
+	/**
+	 * Filter the elements array for the member profile.
+	 *
+	 * @since TBD
+	 * @param array $elements_array The array of elements to display on the member profile.
+	 * @param object $pu The user object.
+	 * @return array $elements_array The array of elements to display on the member profile.
+	 */
+	$elements_array = apply_filters( 'pmpro_member_profile_elements', $elements_array, $pu );
 
 	if(isset($_REQUEST['limit']))
 		$limit = intval($_REQUEST['limit']);
 	elseif(empty($limit))
 		$limit = 15;
 
-	$pu = pmpromd_get_user( $user_id );
-
-	if ( ! empty( $pu ) ) {
-		$pu->membership_level = pmpro_getMembershipLevelForUser( $pu->ID );
-		$allmylevels = pmpro_getMembershipLevelsForUser( $pu->ID );
-		$membership_levels = array();
-		foreach ( $allmylevels as $curlevel ) {
-			$membership_levels[] = $curlevel->name;
-		}
-		$pu->membership_levels = implode(', ', $membership_levels);
-	}
-
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
-		<?php if ( ! empty( $show_search ) ) { ?>
-			<form action="<?php echo esc_url( $directory_url ); ?>" method="post" role="search" class="<?php echo pmpro_get_element_class( 'pmpro_form pmpro_member_directory_search', 'pmpro_member_directory_search' ); ?>">
-				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
-					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-ps', 'pmpro_form_field-ps' ) ); ?>">
-						<label for="ps" class="screen-reader-text"><?php _e('Search for:','pmpro-member-directory'); ?></label>
-						<input type="search" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text' ) ); ?>" placeholder="<?php esc_attr_e( 'Search Members','pmpro-member-directory' ); ?>" name="ps" id="ps" value="<?php if(!empty($_REQUEST['ps'])) echo esc_attr($_REQUEST['ps']);?>" title="<?php esc_attr_e('Search Members','pmpro-member-directory'); ?>" />
-						<input type="hidden" name="limit" value="<?php echo esc_attr($limit);?>" />
-					</div> <!-- end pmpro_form_field-ps -->
-				</div> <!-- end pmpro_form_fields -->
-				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
-					<input type="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn' ) ); ?>" value="<?php esc_attr_e( 'Submit','pmpro-member-directory'); ?>">
-				</div>
-			</form>
-		<?php } ?>
 		<?php
-			if (! empty( $pu ) )
-				{
-				if ( ! empty( $fields ) )
-					{
-					// Check to see if the Block Editor is used or the shortcode.
-					if ( strpos( $fields, "\n" ) !== FALSE ) {
-						$fields = rtrim( $fields, "\n" ); // clear up a stray \n
-						$fields_array = explode("\n", $fields); // For new block editor.
-					} else {
-						$fields = rtrim( $fields, ';' ); // clear up a stray ;
-						$fields_array = explode(";",$fields);
-					}
-
-					if ( ! empty( $fields_array ) ) {
-						for( $i = 0; $i < count($fields_array); $i++ ) {
-							$fields_array[$i] = explode( ',', $fields_array[$i] );
-						}
-					}
-				}
-				else {
-					$fields_array = false;
-				}
-
-				// Get Register Helper field options
-				$rh_fields = array();
-				if(!empty($pmprorh_registration_fields)) {
-					foreach($pmprorh_registration_fields as $location) {
-						foreach($location as $field) {
-							if(!empty($field->options)){
-								$rh_fields[$field->name] = $field->options;
-							}
-						}
-					}
-				}
-				?>
-				<div id="pmpro_member_profile-<?php echo esc_attr( $pu->ID ); ?>" class="<?php echo pmpro_get_element_class( 'pmpro_card pmpro_member_profile', 'pmpro_member_profile'); ?>">
-
-					<?php do_action( 'pmpro_member_profile_before', $pu ); ?>
-
-					<?php
-						if ( ! empty( $show_name ) && ! empty( $pu->display_name ) ) {
-							$heading_classes = array();
-							$heading_classes[] = 'pmpro_card_title';
-							$heading_classes[] = 'pmpro_font-x-large';
-							if ( ! empty( $show_avatar ) ) {
-								$heading_classes[] = 'pmpro_heading-with-avatar';
-							}
-							$heading_classes = implode( ' ', $heading_classes );
-						?>
-						<h2 class="<?php echo esc_attr( pmpro_get_element_class( $heading_classes ) ); ?>">
-							<?php if ( ! empty( $show_avatar ) ) { ?>
-								<?php echo get_avatar($pu->ID, $avatar_size, NULL, $pu->display_name, array("class"=>"alignright")); ?>
-							<?php } ?>	
-							<?php echo esc_html( pmpro_member_directory_get_member_display_name( $pu ) ); ?>
-						</h2>
-					<?php } elseif ( ! empty( $show_avatar ) ) { ?>
-						<div class="pmpro_member_directory_avatar">
-							<?php echo get_avatar($pu->ID, $avatar_size, NULL, $pu->display_name, array("class"=>"alignright")); ?>
-						</div>
-					<?php } ?>
-					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
-						<?php if(!empty($show_bio) && !empty($pu->description) ) { ?>
-							<div class="pmpro_member_directory_bio">
-								<strong><?php _e('Biographical Info', 'pmpro-member-directory'); ?></strong>
-								<?php echo $pu->description; ?>
-							</div>
-						<?php } ?>
-						<?php if(!empty($show_email)) { ?>
-							<div class="pmpro_member_directory_email">
-								<strong><?php _e('Email Address', 'pmpro-member-directory'); ?></strong>
-								<?php echo pmpromd_format_profile_field( $pu->user_email, 'user_email' ); ?>
-							</div>
-						<?php } ?>
-						<?php if(!empty($show_level)) { ?>
-							<div class="pmpro_member_directory_level">
-								<strong><?php _e('Level', 'pmpro-member-directory'); ?></strong>
-								<?php echo ! empty( $pu->membership_levels ) ? $pu->membership_levels : ''; ?>
-							</div>
-						<?php } ?>
-						<?php if(!empty($show_startdate)) { ?>
-							<div class="pmpro_member_directory_date">
-								<strong><?php _e('Start Date', 'pmpro-member-directory'); ?></strong>
-								<?php
-								$min_startdate = null;
-								foreach($allmylevels as $level) {
-									if ( empty( $min_startdate ) || $level->startdate < $min_startdate ) {
-										$min_startdate = $level->startdate;
-									}
-								}
-								echo ! empty( $min_startdate ) ? date_i18n( get_option( 'date_format' ), $min_startdate ) : '';
-								?>
-							</div>
-						<?php } ?>
-						<?php if(!empty($show_billing) && !empty($pu->pmpro_baddress1)) { ?>
-							<div class="pmpro_member_directory_baddress">
-								<strong><?php _e('Address', 'pmpro-member-directory'); ?></strong>
-								<?php echo $pu->pmpro_baddress1; ?><br />
-								<?php
-									if(!empty($pu->pmpro_baddress2))
-										echo $pu->pmpro_baddress2 . "<br />";
-								?>
-								<?php if($pu->pmpro_bcity && $pu->pmpro_bstate) { ?>
-									<?php echo $pu->pmpro_bcity; ?>, <?php echo $pu->pmpro_bstate; ?> <?php echo $pu->pmpro_bzipcode; ?><br />
-									<?php echo $pu->pmpro_bcountry; ?><br />
-								<?php } ?>
-							</div>
-						<?php } ?>
-						<?php if(!empty($show_phone) && !empty($pu->pmpro_bphone)) { ?>
-							<div class="pmpro_member_directory_phone">
-								<strong><?php _e('Phone Number','pmpro-member-directory'); ?></strong>
-								<?php echo formatPhone($pu->pmpro_bphone); ?>
-							</div>
-						<?php } ?>
-						<?php
-							//filter the fields
-							$fields_array = apply_filters( 'pmpro_member_profile_fields', $fields_array, $pu );
-
-							if(!empty($fields_array))
-							{
-								foreach($fields_array as $field)
-								{
-
-									if(empty($field[0]))
-										break;
-
-									// Fix for a trailing space in the 'fields' shortcode attribute.
-									if ( $field[0] === ' ' ) {
-										break;
-									}
-
-									// Get the field name and value here.
-									$field_val = $field[1];
-									$meta_field = $pu->$field_val;
-
-									// If using PMPro 2.10, try use User Field function to display labels.
-									if ( function_exists( 'pmpro_get_label_for_user_field_value' ) && ! empty( $field_val ) && ! empty( $meta_field ) ) {
-										$meta_field = pmpro_get_label_for_user_field_value( $field_val, $meta_field );
-									}
-
-									if(!empty($meta_field))
-									{
-										?>
-										<div class="pmpro_member_directory_<?php echo esc_attr($field[1]); ?>">
-										<?php
-											if(is_array($meta_field) && !empty($meta_field['filename']) ) {
-												//this is a file field
-												?>
-												<strong><?php echo $field[0]; ?></strong>
-												<?php echo pmpromd_display_file_field($meta_field); ?>
-												<?php
-											}elseif(is_array($meta_field)){
-												//this is a general array, check for Register Helper options first
-												if(!empty($rh_fields[$field[1]])) {
-													foreach($meta_field as $key => $value)
-														$meta_field[$key] = $rh_fields[$field[1]][$value];
-												}
-												?>
-												<strong><?php echo $field[0]; ?></strong>
-												<?php echo implode(", ",$meta_field); ?>
-												<?php
-											}
-											elseif(!empty($rh_fields[$field[1]])  && is_array($rh_fields[$field[1]]) )
-											{
-											?>
-												<strong><?php echo $field[0]; ?></strong>
-												<?php echo $rh_fields[$field[1]][$meta_field]; ?>
-												<?php
-											}
-											else
-											{
-												if($field[1] == 'user_url')
-												{
-													echo pmpromd_format_profile_field( $meta_field, $field[1], $field[0] );
-												}
-												else
-												{
-													?>
-													<strong><?php echo $field[0]; ?></strong>
-													<?php
-														echo pmpromd_format_profile_field( $meta_field, $field[1] );
-												}
-											}
-										?>
-
-
-										</div>
-										<?php
-									}
-								}
-							}
-						?>
-						<?php do_action( 'pmpro_member_profile_after', $pu ); ?>
-					</div> <!-- end pmpro_card_content -->
-					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
-						<?php
-							// Build the links to return.
-							$pmpro_member_profile_action_links = array();
-
-							if ( ! empty( $directory_url ) ) {
-								$pmpro_member_profile_action_links['view-directory'] = sprintf( '<a id="pmpro_actionlink-view-all-members" href="%s">%s</a>', esc_url( $directory_url ), esc_html__( 'View All Members', 'pmpro-member-directory' ) );
-							}
-
-							if ( ! empty( $pu ) && $pu->ID === $current_user->ID ) {
-								// User viewing their own profile. Show an edit profile link if 'Member Profile Edit Page' is set or dashboard access is allowed.
-								if ( ! empty( get_option( 'pmpro_member_profile_edit_page_id' ) ) ) {
-									$edit_profile_url = pmpro_url( 'member_profile_edit' );
-								} elseif ( ! pmpro_block_dashboard() ) {
-									$edit_profile_url = admin_url( 'profile.php' );
-								}
-
-								if ( ! empty( $edit_profile_url) ) {
-									$pmpro_member_profile_action_links['edit-profile'] = sprintf( '<a id="pmpro_actionlink-profile" href="%s">%s</a>', esc_url( $edit_profile_url ), esc_html__( 'Edit Profile', 'paid-memberships-pro' ) );
-								}
-							}
-
-							/**
-							 * Filter which links are displayed on the single Member Directory Profile page.
-							 *
-							 * @since 1.0
-							 *
-							 * @param array $pmpro_member_profile_action_links Can be view-directory, edit-profile, or or custom.
-							 *
-							 * @return array $pmpro_member_profile_action_links
-							 */
-							$pmpro_member_profile_action_links = apply_filters( 'pmpromd_member_profile_action_links', $pmpro_member_profile_action_links );
-
-							$allowed_html = array(
-								'a' => array (
-									'class' => array(),
-									'href' => array(),
-									'id' => array(),
-									'target' => array(),
-									'title' => array(),
-								),
-							);
-							echo wp_kses( implode( pmpro_actions_nav_separator(), $pmpro_member_profile_action_links ), $allowed_html );
-						?>
-					</div> <!-- end pmpro_card_actions -->
-				</div> <!-- end pmpro_card -->
-				<?php
+			if ( ! empty( $show_search ) ) {
+				echo pmpromd_search_form();
 			}
 		?>
+
+		<?php
+			// TODO: Do we need to check if a have a user here? Shouldn't earlier redirects be handling that?
+		?>
+
+		<div id="pmpro_member_profile-<?php echo esc_attr( $pu->ID ); ?>" class="<?php echo pmpro_get_element_class( 'pmpro_card pmpro_member_profile', 'pmpro_member_profile'); ?>">
+
+			<?php
+				/**
+				 * Fires before the member profile fields are displayed.
+				 *
+				 * @since 0.8
+				 * @param object $pu The user object.
+				 *
+				 */
+				do_action( 'pmpro_member_profile_before', $pu );
+			?>
+
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+				<?php
+					foreach ( $elements_array as $element ) {
+						$value = pmpromd_get_display_value( $element[1], $pu );
+						if ( ! empty( $value ) ) {
+							?>
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . $element[1] ) ); ?>">
+								<?php if ( ! empty( $element[0] ) ) { ?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field_label' ) ); ?>">
+										<?php echo esc_html( $element[0] ); ?>
+									</div>
+								<?php } ?>
+								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field_data' ) ); ?>">
+									<?php echo $value; ?>
+								</div>
+							</div> <!-- end pmpro_member_profile_field -->
+							<?php
+						}
+					}
+				?>
+
+				<?php
+					/**
+					 * Fires before the member profile fields are displayed.
+					 *
+					 * @since 0.8
+					 * @param object $pu The user object.
+					 *
+					 */
+					do_action( 'pmpro_member_profile_after', $pu );
+				?>
+			</div> <!-- end pmpro_card_content -->
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
+				<?php
+					// Build the links to return.
+					$pmpro_member_profile_action_links = array();
+
+					if ( ! empty( $directory_url ) ) {
+						$pmpro_member_profile_action_links['view-directory'] = sprintf( '<a id="pmpro_actionlink-view-all-members" href="%s">%s</a>', esc_url( $directory_url ), esc_html__( 'View All Members', 'pmpro-member-directory' ) );
+					}
+
+					if ( ! empty( $pu ) && $pu->ID === $current_user->ID ) {
+						// User viewing their own profile. Show an edit profile link if 'Member Profile Edit Page' is set or dashboard access is allowed.
+						if ( ! empty( get_option( 'pmpro_member_profile_edit_page_id' ) ) ) {
+							$edit_profile_url = pmpro_url( 'member_profile_edit' );
+						} elseif ( ! pmpro_block_dashboard() ) {
+							$edit_profile_url = admin_url( 'profile.php' );
+						}
+
+						if ( ! empty( $edit_profile_url) ) {
+							$pmpro_member_profile_action_links['edit-profile'] = sprintf( '<a id="pmpro_actionlink-profile" href="%s">%s</a>', esc_url( $edit_profile_url ), esc_html__( 'Edit Profile', 'paid-memberships-pro' ) );
+						}
+					}
+
+					/**
+					 * Filter which links are displayed on the single Member Directory Profile page.
+					 *
+					 * @since 1.0
+					 *
+					 * @param array $pmpro_member_profile_action_links Can be view-directory, edit-profile, or or custom.
+					 *
+					 * @return array $pmpro_member_profile_action_links
+					 */
+					$pmpro_member_profile_action_links = apply_filters( 'pmpromd_member_profile_action_links', $pmpro_member_profile_action_links );
+
+					$allowed_html = array(
+						'a' => array (
+							'class' => array(),
+							'href' => array(),
+							'id' => array(),
+							'target' => array(),
+							'title' => array(),
+						),
+					);
+					echo wp_kses( implode( pmpro_actions_nav_separator(), $pmpro_member_profile_action_links ), $allowed_html );
+				?>
+			</div> <!-- end pmpro_card_actions -->
+		</div> <!-- end pmpro_card -->
 	</div> <!-- end pmpro -->
 	<?php
 	$temp_content = ob_get_contents();
 	ob_end_clean();
 	return $temp_content;
 }
-add_shortcode("pmpro_member_profile", "pmpromd_profile_shortcode");
+add_shortcode( 'pmpro_member_profile', 'pmpromd_profile_shortcode' );

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -123,7 +123,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 				<?php
 					foreach ( $elements_array as $element ) {
-						$value = pmpromd_get_display_value( $element[1], $pu );
+						$value = pmpromd_get_display_value( $element[1], $pu, 'profile' );
 						if ( ! empty( $value ) ) {
 							?>
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . $element[1] ) ); ?>">

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -123,8 +123,12 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 				<?php
 					foreach ( $elements_array as $element ) {
-						$value = pmpromd_get_display_value( $element[1], $pu, 'profile' );
+						$value = pmpromd_get_display_value( $element[1], $pu );
 						if ( ! empty( $value ) ) {
+							// If this is the display_name, we need to wrap it in an h2 tag.
+							if ( 'display_name' === $element[1] ) {
+								$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . $value . '</h2>';
+							}
 							?>
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . $element[1] ) ); ?>">
 								<?php if ( ! empty( $element[0] ) ) { ?>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -68,7 +68,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 			$elements .= __( 'Start Date', 'pmpro-member-directory' ) . ',membership_startdate;';
 		}
 		if ( ! empty( $show_billing ) ) {
-			$elements .= __( 'Address', 'pmpro-member-directory' ) . ',pmpro_baddress1|pmpro_baddress2|pmpro_bcity|pmpro_bstate|pmpro_bzipcode|pmpro_bcountry;';
+			$elements .= __( 'Address', 'pmpro-member-directory' ) . ',pmpro_billing_address;';
 		}
 		if ( ! empty( $show_phone ) ) {
 			$elements .= __( 'Phone Number', 'pmpro-member-directory' ) . ',pmpro_bphone;';
@@ -130,7 +130,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 								$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . $value . '</h2>';
 							}
 							?>
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . $element[1] ) ); ?>">
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field pmpro_member_profile_field-' . strtok( $element[1], '|' ) ) ); ?>">
 								<?php if ( ! empty( $element[0] ) ) { ?>
 									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_profile_field_label' ) ); ?>">
 										<?php echo esc_html( $element[0] ); ?>

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -39,6 +39,9 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 	$show_search = filter_var( $show_search, FILTER_VALIDATE_BOOLEAN );
 	$show_startdate = filter_var( $show_startdate, FILTER_VALIDATE_BOOLEAN );
 
+	// Validate the avatar size.
+	$avatar_size = intval( $avatar_size );
+
 	// Build our elements array. If we have an elements attribute on the shortcode, use that and ignore any other legacy attributes.
 	if ( ! empty( $elements ) ) {
 		$elements_array = pmpromd_prepare_elements_array( $elements );
@@ -49,11 +52,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 			$elements .= 'display_name;';
 		}
 		if ( ! empty( $show_avatar ) ) {
-			if ( ! empty( $avatar_size ) ) {
-				$elements .= 'avatar|' . $avatar_size . ';';
-			} else {
-				$elements .= 'avatar;';
-			}
+			$elements .= 'avatar|' . $avatar_size . ';';
 		}
 		if ( ! empty( $show_bio ) ) {
 			$elements .= __( 'Biographical Info', 'pmpro-member-directory' ) . ',description;';

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -7,6 +7,8 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 		'avatar_size' => '128',
 		'elements' => NULL,
 		'fields' => NULL,
+		'level' => NULL,
+		'levels' => NULL,
 		'show_avatar' => true,
 		'show_bio' => true,
 		'show_billing' => true,
@@ -27,6 +29,16 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 
 	// Get the user for this profile.
 	$pu = pmpromd_get_user( $user_id );
+
+	// Did they use level instead of levels?
+	if ( empty( $levels ) && ! empty( $level ) ) {
+		$levels = $level;
+	}
+
+	// Convert the levels attribute to an array.
+	if ( is_array( $levels ) ) {
+		$levels = implode( ',', $levels );
+	}
 
 	// Validate boolean variables.
 	$show_avatar = filter_var( $show_avatar, FILTER_VALIDATE_BOOLEAN );
@@ -89,6 +101,9 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 	 */
 	$elements_array = apply_filters( 'pmpro_member_profile_elements', $elements_array, $pu );
 
+	// Set the displayed_levels variable to use for displaying values.
+	$displayed_levels = empty( $levels ) ? 'all' : $levels;
+
 	if(isset($_REQUEST['limit']))
 		$limit = intval($_REQUEST['limit']);
 	elseif(empty($limit))
@@ -101,10 +116,6 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 			if ( ! empty( $show_search ) ) {
 				echo pmpromd_search_form();
 			}
-		?>
-
-		<?php
-			// TODO: Do we need to check if a have a user here? Shouldn't earlier redirects be handling that?
 		?>
 
 		<div id="pmpro_member_profile-<?php echo esc_attr( $pu->ID ); ?>" class="<?php echo pmpro_get_element_class( 'pmpro_card pmpro_member_profile', 'pmpro_member_profile'); ?>">
@@ -123,7 +134,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 				<?php
 					foreach ( $elements_array as $element ) {
-						$value = pmpromd_get_display_value( $element[1], $pu );
+						$value = pmpromd_get_display_value( $element[1], $pu, $displayed_levels );
 						if ( ! empty( $value ) ) {
 							// If this is the display_name, we need to wrap it in an h2 tag.
 							if ( 'display_name' === $element[1] ) {


### PR DESCRIPTION
Improving the directory and profile shortcodes to leverage the `elements` attribute that will accept user, usermeta, or a few "specific to the Directory Add On" named elements.

The shortcode's `elements` attribute will display items in the order they are listed. Just like the former `fields` attribute, people can set a "name" to label the displayed element value in the format: "Label,name;Label2,name2;".

You can also now set no label and just display the element value in the format: "name;name2;".

Here's an example shortcode using the `elements` attribute:
`[pmpro_member_profile elements="About Me,description;Profile Video,video" show_search="false"]`

The former shortcode attributes will still work but we do not plan to support those forever.

For now, we use the `elements` attribute values only (if present) and ignore all other old attributes.

If we do not see an `elements` attribute, we set up the former attributes either based on the user-specified shortcode attributes or the former defaults for those values.

This PR also includes a renamed filter hook and start of a deprecation file / notice system just like core PMPro uses.

This PR adds a new function to show the "search" form and a shortcode wrapper so sites can place the search other places.

This PR also fixes #161 with a new function to set the document <title> tag.

There are still a couple functions in the main plugin file that will most likely be deprecated or replaced in the next version or a future version. We have to be careful since these function names may be used in a custom theme-loaded template.

