### PR TITLE
Deprecate showing billing address

### DIFF
--- a/blocks/profile/block.js
+++ b/blocks/profile/block.js
@@ -128,7 +128,7 @@ export default registerBlockType(
                 />
 
                 <CheckboxControl 
-                  label='Show Billing'
+                  label='Show Billing (Deprecated)'
                   checked={ show_billing }
                   onChange={ show_billing => { setAttributes( { show_billing } ) } }
                 />
@@ -145,7 +145,7 @@ export default registerBlockType(
                 />
 
                 <CheckboxControl 
-                  label='Show Phone'
+                  label='Show Phone (deprecated)'
                   checked={ show_phone }
                   onChange={ show_phone => { setAttributes( { show_phone } ) } }
                 />

--- a/blocks/profile/block.js
+++ b/blocks/profile/block.js
@@ -128,7 +128,7 @@ export default registerBlockType(
                 />
 
                 <CheckboxControl 
-                  label='Show Billing (Deprecated)'
+                  label='Show Billing (deprecated)'
                   checked={ show_billing }
                   onChange={ show_billing => { setAttributes( { show_billing } ) } }
                 />

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -495,6 +495,7 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 				$value = $enddate;
 				break;
 			case 'pmpro_billing_address':
+				_doing_it_wrong( __FUNCTION__, esc_html__( 'The pmpro_billing_address element is deprecated. Use pmpro_mailing_address instead.', 'pmpro-member-directory' ), 'TBD' );
 				$value = pmpro_formatAddress(
 					trim( $pu->pmpro_bfirstname . ' ' . $pu->pmpro_blastname ),
 					$pu->pmpro_baddress1,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -495,7 +495,7 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 				$value = $enddate;
 				break;
 			case 'pmpro_billing_address':
-				_doing_it_wrong( __FUNCTION__, esc_html__( 'The pmpro_billing_address element is deprecated. Use pmpro_mailing_address instead.', 'pmpro-member-directory' ), 'TBD' );
+				_doing_it_wrong( __FUNCTION__, esc_html__( 'The show_billing attribute is deprecated. We recommend collecting member addresses using the Mailing Address Add On or through User Fields.', 'pmpro-member-directory' ), 'TBD' );
 				$value = pmpro_formatAddress(
 					trim( $pu->pmpro_bfirstname . ' ' . $pu->pmpro_blastname ),
 					$pu->pmpro_baddress1,
@@ -508,7 +508,7 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 				);
 				break;
 			case 'pmpro_bphone':
-				_doing_it_wrong( __FUNCTION__, esc_html__( 'The pmpro_bphone element is deprecated. Collect phone numbers in a user field instead.', 'pmpro-member-directory' ), 'TBD' );
+				_doing_it_wrong( __FUNCTION__, esc_html__( 'The show_phone attribute is deprecated. We recommend collecting member phone numbers through a User Field.', 'pmpro-member-directory' ), 'TBD' );
 				break;
 			case 'pmpro_shipping_address':
 			case 'pmpro_mailing_address':

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -507,6 +507,9 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 					$pu->pmpro_bphone
 				);
 				break;
+			case 'pmpro_bphone':
+				_doing_it_wrong( __FUNCTION__, esc_html__( 'The pmpro_bphone element is deprecated. Collect phone numbers in a user field instead.', 'pmpro-member-directory' ), 'TBD' );
+				break;
 			case 'pmpro_shipping_address':
 			case 'pmpro_mailing_address':
 				$value = pmpro_formatAddress(

--- a/readme.txt
+++ b/readme.txt
@@ -41,10 +41,8 @@ Shortcode attributes for `[pmpro_member_profile]` include:
 1. fields: Display additional user meta fields. default: none (accepts a list of label names and field IDs, i.e. fields="Company,company;Website,user_url").
 1. show_avatar: Display the user's avatar generated via Gravatar (https://en.gravatar.com) or user-submitted using a plugin like Simple Local Avatars (https://wordpress.org/plugins/simple-local-avatars/); default: true (accepts 'true' or 'false').
 1. show_bio: Display the user's bio (if available); default: true (accepts 'true' or 'false').
-1. show_billing: Display the user's billing address (if available); default: true (accepts 'true' or 'false').
 1. show_email: Display the user's email address; default: true (accepts 'true' or 'false').
 1. show_level: Display the user's membership level; default: true  (accepts 'true' or 'false').
-1. show_phone: Display the user's billing phone (if available); default: true (accepts 'true' or 'false').
 1. show_search: Display a search form (searches on member display name or email address); default: true (accepts 'true' or 'false').
 1. show_startdate: Display the user's membership start date for their current level; default: true (accepts 'true' or 'false').
 1. user_id: Show a specific member's profile; default: none (accepts any numeric uesr id, i.e. user_id="125").
@@ -77,13 +75,13 @@ Show a unique member directory by level. Level 1 Members can only see other Leve
 [pmpro_member_directory levels="3"]
 [/membership]
 
-Show unique member profiles based on level - hide user phone number and email address.
+Show unique member profiles based on level - hide user email address.
 [membership level="1"]
-[pmpro_member_profile show_email="false" show_phone="false"]
+[pmpro_member_profile show_email="false"]
 [/membership]
 
 [membership level="2"]
-[pmpro_member_profile show_email="true" show_phone="true"]
+[pmpro_member_profile show_email="true"]
 [/membership]
 
 == Frequently Asked Questions ==


### PR DESCRIPTION
Alternative to #171 

Sites should show a member's mailing/shipping/physical/other address instead of the address associated with their payment method.