### PR TITLE
Fixes warning for undefined value variable

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -419,6 +419,9 @@ function pmpromd_prepare_elements_array( $elements ) {
  * Get the value of a specific element from a string of HTML.
  */
 function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
+	// Initialize the value.
+	$value = '';
+
 	// Is this a user field?
 	if ( class_exists( 'PMPro_Field_Group' ) ) {
 		$user_field = PMPro_Field_Group::get_field( $element );

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -350,7 +350,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 								// Loop through the elements and output the content.
 								foreach ( $elements_array as $element ) {
 									$value = pmpromd_get_display_value( $element[1], $auser, $displayed_levels );
-									if ( ! empty( $value ) ) {
+									if ( ! empty( $value ) || ( is_string( $value ) && strlen( $value ) > 0 ) ) { // The string '0' is empty(), but we want to show it.
 										// Wrap the value in a link if the element is in the linked elements array.
 										if ( ! empty( $link ) && ! empty( $profile_url ) &&in_array( $element[1], $linked_elements ) ) {
 											$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -350,7 +350,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 								// Loop through the elements and output the content.
 								foreach ( $elements_array as $element ) {
 									$value = pmpromd_get_display_value( $element[1], $auser, $displayed_levels );
-									if ( ! empty( $value ) || ( is_string( $value ) && strlen( $value ) > 0 ) ) { // The string '0' is empty(), but we want to show it.
+									if ( ! empty( $value ) || $value === '0' ) {
 										// Wrap the value in a link if the element is in the linked elements array.
 										if ( ! empty( $link ) && ! empty( $profile_url ) &&in_array( $element[1], $linked_elements ) ) {
 											$value = '<a href="' . esc_url( pmpromd_build_profile_url( $auser, $profile_url ) ) . '">' . $value . '</a>';

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -144,7 +144,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 				<?php
 					foreach ( $elements_array as $element ) {
 						$value = pmpromd_get_display_value( $element[1], $pu, $displayed_levels );
-						if ( ! empty( $value ) || ( is_string( $value ) && strlen( $value ) > 0 ) ) { // The string '0' is empty(), but we want to show it.
+						if ( ! empty( $value ) || $value === '0' ) {
 							// If this is the display_name, we need to wrap it in an h2 tag.
 							if ( 'display_name' === $element[1] ) {
 								$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . $value . '</h2>';

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -144,7 +144,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 				<?php
 					foreach ( $elements_array as $element ) {
 						$value = pmpromd_get_display_value( $element[1], $pu, $displayed_levels );
-						if ( ! empty( $value ) ) {
+						if ( ! empty( $value ) || ( is_string( $value ) && strlen( $value ) > 0 ) ) { // The string '0' is empty(), but we want to show it.
 							// If this is the display_name, we need to wrap it in an h2 tag.
 							if ( 'display_name' === $element[1] ) {
 								$value = '<h2 class="' . pmpro_get_element_class( 'pmpro_font-x-large' ) . '">' . $value . '</h2>';


### PR DESCRIPTION
$value would be not defined in some cases, so when we get to the filter line, this would cause a warning.