### PR TITLE
Fixing early return if no results missing closed HTML tags

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -185,6 +185,8 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 						}
 					?>
 				</div>
+				</div> <!-- end pmpro_member_directory_before -->
+				</div> <!-- end pmpro -->
 				<?php
 				$temp_content = ob_get_contents();
 				ob_end_clean();


### PR DESCRIPTION
If the directory has no results, we are now returning early. But we are missing the closing div tags for the outer elements when we return this.