### PR TITLE
Now leveraging the pagination function from core PMPro

### DIFF
--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -185,6 +185,42 @@ div.pmpro_member_profile strong {display: block; }
 	}
 }
 
+/* This is legacy core PMPro pagination styling to support sites that are running PMPro < 3.4.3 */
+.pmpro_pagination {
+	align-items: center;
+	display: flex;
+	gap: var(--pmpro--base--spacing--small);
+	justify-content: center;
+	margin: var(--pmpro--base--spacing--medium) 0;
+
+	a {
+		background-color: var(--pmpro--color--base);
+		border: 1px solid var(--pmpro--color--border--variation);
+		border-radius: var(--pmpro--base--border-radius);
+		color: var(--pmpro--color--contrast);
+		padding: 2px var(--pmpro--base--spacing--small);
+		text-decoration: none;
+		transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+
+		&:hover {
+			background-color: var(--pmpro--color--accent--variation);
+			border-color: var(--pmpro--color--accent--variation);
+			color: var(--pmpro--color--base);
+		}
+
+	}
+
+	span.current {
+		background-color: var(--pmpro--color--accent);
+		border: 1px solid var(--pmpro--color--border--variation);
+		border-radius: var(--pmpro--base--border-radius);
+		color: var(--pmpro--color--base);
+		font-weight: 700;
+		padding: 2px var(--pmpro--base--spacing--small);
+	}
+
+}
+
 /* This is legacy pagination styling we can leave in here until we remove templating. */
 .pmpro_page_numbers a {
 	padding: 6px;

--- a/css/pmpro-member-directory.css
+++ b/css/pmpro-member-directory.css
@@ -185,45 +185,6 @@ div.pmpro_member_profile strong {display: block; }
 	}
 }
 
-/**
- * Pagination/page numbers
- */
-.pmpro_member_directory_pagination {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	gap: var(--pmpro--base--spacing--small);
-	margin: var(--pmpro--base--spacing--medium) 0;
-
-	a {
-		background-color: var(--pmpro--color--base);
-		border: 1px solid var(--pmpro--color--border--variation);
-		border-radius: var(--pmpro--base--border-radius);
-		color: var(--pmpro--color--contrast);
-		padding: 2px var(--pmpro--base--spacing--small);
-		text-decoration: none;
-		transition: background-color 0.2s, border-color 0.2s, color 0.2s;
-
-		&:hover {
-			background-color: var(--pmpro--color--accent--variation);
-			border-color: var(--pmpro--color--accent--variation);
-			color: var(--pmpro--color--base);
-		}
-
-		&.pmpro_member_directory_pagination-current {
-			background-color: var(--pmpro--color--accent);
-			color: var(--pmpro--color--base);
-			cursor: default;
-			font-weight: 700;
-		}
-
-		&.pmpro_member_directory_pagination-previous {
-			margin-right: 0;
-		}
-	}
-
-}
-
 /* This is legacy pagination styling we can leave in here until we remove templating. */
 .pmpro_page_numbers a {
 	padding: 6px;

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -403,67 +403,24 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 				do_action( 'pmpro_member_directory_after', $sqlQuery, $shortcode_atts );
 			?>
 
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_pagination' ) ); ?>">
-				<?php
-				//prev
-				if ( $pn > 1 ) {
-					$query_args = array(
-						'ps' => $s,
-						'pn' => $pn-1,
-						'limit' => $limit,
-					);
-					$query_args = apply_filters( 'pmpromd_pagination_url', $query_args, 'prev' );
-					?>
-					<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_pagination-previous' ) ); ?>" href="<?php echo esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) );?>" title="<?php esc_attr_e( 'Previous Page', 'pmpro-member-directory' ); ?>"><?php esc_html_e( '&larr; Previous', 'pmpro-member-directory' ); ?></a>
-					<?php
-				}
+			<?php
+				// Show the pagination.
+				$target_page_query_args = array(
+					'ps' => $s,
+					'limit' => $limit,
+				);
+				$pagination = pmpro_getPaginationString(
+					$pn,
+					$totalrows,
+					$limit,
+					1,
+					esc_url( add_query_arg( $target_page_query_args, get_permalink( $post->ID ) ) ),
+					'&pn=',
+					__( 'Member Directory Pagination', 'pmpro-member-directory' )
+				);
+				echo wp_kses_post( $pagination );
+			?>
 
-				$number_of_pages = $totalrows / $limit;
-				//Page Numbers
-				$counter = 0;
-				if ( empty( $pn ) || $pn != 1 ) {
-					echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" title="' . esc_attr__( 'Previous', 'pmpro-member-directory' ) . '">...</a>';
-				}
-
-				if ( round( $number_of_pages, 0 ) !== 1 && $pn !== 1 ) {
-					//If there's only one page, no need to show the page numbers
-					for( $i = $pn; $i <= $number_of_pages; $i++ ){
-						if( $counter <= 6 ){
-							$query_args = array(
-								'ps' => $s,
-								'pn' => $i,
-								'limit' => $limit,
-							);
-
-							$classes = array();
-							$classes[] = 'pmpro_member_directory_pagination-page';
-							if ( $i == $pn ) {
-								$classes[] = 'pmpro_member_directory_pagination-current';
-							}
-							$classes = implode(	' ', $classes );
-							// translators: placeholder is for page number.
-							echo '<a href="' . esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) ) . '" class="' . esc_attr( pmpro_get_element_class( $classes ) ) . '" title="' . esc_attr( sprintf( __('Page %s', 'pmpro-member-directory' ), $i ) ) . '">' . esc_html( $i ) . '</a>';
-						}
-						$counter++;
-					}
-				}
-				?>
-
-				<?php
-				//next
-				if ( $totalrows > $end ) {
-					$query_args = array(
-						'ps' => $s,
-						'pn' => $pn+1,
-						'limit' => $limit,
-					);
-					$query_args = apply_filters( 'pmpromd_pagination_url', $query_args, 'next' );
-					?>
-					<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_member_directory_pagination-next' ) ); ?>" href="<?php echo esc_url( add_query_arg( $query_args, get_permalink( $post->ID ) ) );?>" title="<?php esc_attr_e( 'Next Page', 'pmpro-member-directory' ); ?>"><?php esc_html_e( 'Next &rarr;', 'pmpro-member-directory' ); ?></a>
-					<?php
-				}
-				?>
-			</div> <!-- end pmpro_pagination -->
 		</div> <!-- end pmpro_member_directory_after -->
 	</div> <!-- end pmpro -->
 	<?php

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -404,11 +404,18 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 			?>
 
 			<?php
+				/**
+				 * Filter the query arguments for the pagination URL.
+				 *
+				 * @since 0.7
+				 * @deprecated TBD The `$type` parameter is no longer used.
+				 *
+				 * @param array $query_args The query arguments for the pagination URL.
+				 * @param string $type (deprecated) The type of pagination URL to get. This parameter is no longer used.
+				 */
+				$target_page_query_args = apply_filters( 'pmpromd_pagination_url', array( 'ps' => $s, 'limit' => $limit ), 'prev' );
+
 				// Show the pagination.
-				$target_page_query_args = array(
-					'ps' => $s,
-					'limit' => $limit,
-				);
 				$pagination = pmpro_getPaginationString(
 					$pn,
 					$totalrows,


### PR DESCRIPTION
Updated to use the core function `pmpro_getPaginationString` to build the pagination.

This update is somewhat tied to https://github.com/strangerstudios/paid-memberships-pro/pull/3343/ but can be released without it.

The best approach would be to release these two around the same time so that the updated and more accessible markup for the core pagination function is used.

There is legacy CSS for the former PMPro core pagination markup in this. There is no conflict in the appearance if the sites are running the updated markup alongside this CSS.

Appearance without the update in core PMPro:

![Screenshot 2025-03-18 at 7 06 20 AM](https://github.com/user-attachments/assets/878079b1-f1bd-4483-b898-4d2212adfea5)


Appearance with the update in core PMPro:

![Screenshot 2025-03-18 at 6 58 15 AM](https://github.com/user-attachments/assets/b62ae195-24da-433f-9953-201ae8e449a1)

