### PR TITLE
Fixing version constant when editing posts

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -12,7 +12,7 @@ function pmpromd_register_profile_styling() {
 		'pmpromd-block-styling',
 		plugins_url( '/css/blocks.css', __FILE__ ),
 		array(),
-		PMPRO_VERSION
+		PMPRO_MEMBER_DIRECTORY_VERSION
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'pmpromd_register_profile_styling' );


### PR DESCRIPTION
Ensures that block styling is updated when the Member Directory Add On is updated and avoids a fatal error when using the block editor with PMPro disabled.