### PR TITLE
Now allowing displaying user ID as an element

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -542,6 +542,7 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 					'user_url',
 					'user_registered',
 					'display_name',
+					'ID',
 				);
 
 				if ( in_array( $element, $user_column_fields ) ) {


### PR DESCRIPTION
Previously, user ID could not be displayed as an element. This can now be done using the element `ID`.