### PR TITLE
Fix subdomains/subdirectory profile pages

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -222,16 +222,15 @@ function pmpromd_custom_rewrite_rules() {
 		return;
 	}
 
-	$structure = get_option( 'permalink_structure' );
-	if ( empty( $structure ) ) {
-		return;
-	}
-
 	// Get the profile permalink.
 	$profile_permalink = get_permalink( $pmpro_pages['profile'] );
 
 	// Parse the path from the permalink, taking subfolder installations into account.
-	$profile_base = trim( parse_url( $profile_permalink, PHP_URL_PATH ), '/' );
+	$profile_page = get_post( $pmpro_pages['profile'] );
+	if ( ! is_object( $profile_page ) || empty( $profile_page->post_name ) ) {
+		return;
+	}
+	$profile_base = $profile_page->post_name;
 
 	// Add the rewrite rule.
 	add_rewrite_rule(


### PR DESCRIPTION
* BUG FIX: Fixed issues where the profile page would not load correctly on subdirectory installs.

Resolves: https://github.com/strangerstudios/pmpro-member-directory/issues/189

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?