### PR TITLE
Adjust the initial shortcode when installed.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -42,12 +42,12 @@ add_action( 'admin_bar_menu', 'pmpromd_add_edit_profile', 100 );
 function pmpromd_extra_page_settings( $pages ) {
 	$pages['directory'] = array(
 		'title' => esc_html__( 'Directory', 'pmpro-member-directory' ),
-		'content' => '[pmpro_member_directory]',
+		'content' => '[pmpro_member_directory layout="3col" elements="avatar;display_name;membership_name"]',
 		'hint' => esc_html__( 'Include the shortcode [pmpro_member_directory].', 'pmpro-member-directory' ),
 	);
 	$pages['profile'] = array(
 		'title' => esc_html__( 'Profile', 'pmpro-member-directory' ),
-		'content' => '[pmpro_member_profile]',
+		'content' => '[pmpro_member_profile elements="avatar|256;Membership,membership_name;Member Since,membership_startdate" show_search="false"]',
 		'hint' => esc_html__( 'Include the shortcode [pmpro_member_profile].', 'pmpro-member-directory' ),
 	);
 


### PR DESCRIPTION
* ENHANCEMENT: The starting shortcode now includes elements.

Resolves: https://github.com/strangerstudios/pmpro-member-directory/issues/178

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?
