### PR TITLE
Add support for child pages

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -234,6 +234,14 @@ function pmpromd_custom_rewrite_rules() {
 	}
 	$profile_base = $profile_page->post_name;
 
+	// Add support for profile parent if it's configured.
+	if ( ! empty( $profile_page->post_parent ) ) {
+		$profile_parent = get_post( $profile_page->post_parent );
+		if ( is_object( $profile_parent ) && ! empty( $profile_parent->post_name ) ) {
+			$profile_base = $profile_parent->post_name . '/' . $profile_base;
+		}
+	}
+
 	// Add the rewrite rule.
 	add_rewrite_rule(
 		'^' . preg_quote( $profile_base, '#' ) . '/([^/]+)/?$',


### PR DESCRIPTION
* BUG FIX: Fixes an issue if the profile page is a child page of another page.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves: https://github.com/strangerstudios/pmpro-member-directory/issues/204

### How to test the changes in this Pull Request:

1. Ensure your Member Profile page has a parent page set (i.e. Directory)
2. Flush your permalinks and view a profile page of a member and it should show data and not return a 404.
