### PR TITLE
Escape display name in get_avatar() to prevent broken avatars

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -629,7 +629,7 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 				$value = pmpro_member_directory_get_member_display_name( $pu );
 				break;
 			case 'avatar':
-				$value = get_avatar( $pu->ID, $avatar_size, NULL, $pu->display_name );
+				$value = get_avatar( $pu->ID, $avatar_size, NULL, esc_attr( $pu->display_name ) );
 				break;
 			case 'membership_name':
 				$value = $pu->membership_levels;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Escape the `$pu->display_name` in `get_avatar()` to prevent HTML breakage when display names contain apostrophes or special characters. -->

Resolves: https://github.com/strangerstudios/pmpro-member-directory/issues/209

### How to test the changes in this Pull Request:

1. Create a user named O’Leary
2. Upload an avatar
3. View directory, confirm avatar loads

### Changelog entry

> Escaped display name in avatar `alt` attribute to prevent broken HTML in member directory
