### PR TITLE
fix: escape alt atrribute when getting user's avatar on directory

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -629,7 +629,7 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 				$value = pmpro_member_directory_get_member_display_name( $pu );
 				break;
 			case 'avatar':
-				$value = get_avatar( $pu->ID, $avatar_size, NULL, $pu->display_name );
+				$value = get_avatar( $pu->ID, $avatar_size, NULL, esc_attr( $pu->display_name ) );
 				break;
 			case 'membership_name':
 				$value = $pu->membership_levels;


### PR DESCRIPTION
fixes strangerstudios/pmpro-member-directory#209

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When a member’s display name includes an apostrophe or other special character (e.g., O’Leary), their avatar fails to display in the Member Directory. This happens because the display name is passed directly to the alt attribute in get_avatar() without escaping, breaking the HTML. This fixes the issue.

### How to test the changes in this Pull Request:

1. Ensure the Member Directory & Profile Pages add-on is active.
2. Upload an avatar/profile image for a user.
3. Set the user’s display name to include an apostrophe (e.g., Mary O’Leary).
4. Visit the Member Directory page — the avatar should load.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Escaped alt attribute when getting an user avatar.