### PR TITLE
Fixes API Key Not Being Tested on Save

### DIFF
--- a/includes/google-maps/includes/admin.php
+++ b/includes/google-maps/includes/admin.php
@@ -44,7 +44,10 @@ add_filter( 'pmpro_custom_advanced_settings', 'pmpromd_add_google_maps_api_key_s
 function pmpromd_test_maps_api() {
 
 	// Only load this function if the PMPro Advanced Settings page is being loaded.
-	if ( ! isset( $_REQUEST['page'] ) || $_REQUEST['page'] !== 'pmpro-advanced-settings' || ! check_admin_referer( 'savesettings', 'pmpro_advancedsettings_nonce' ) ) {
+	if ( 
+		( ! isset( $_REQUEST['page'] ) && $_REQUEST['page'] !== 'pmpro-advancedsettings' ) && 
+		( ! empty($_REQUEST['pmpro_advancedsettings_nonce'] ) &&  ! check_admin_referer( 'savesettings', 'pmpro_advancedsettings_nonce' ) ) 
+		) {
 		return;
 	}
 

--- a/includes/google-maps/includes/admin.php
+++ b/includes/google-maps/includes/admin.php
@@ -43,11 +43,10 @@ add_filter( 'pmpro_custom_advanced_settings', 'pmpromd_add_google_maps_api_key_s
  */
 function pmpromd_test_maps_api() {
 
-	// Only load this function if the PMPro Advanced Settings page is being loaded.
-	if ( 
-		( ! isset( $_REQUEST['page'] ) && $_REQUEST['page'] !== 'pmpro-advancedsettings' ) && 
-		( ! empty($_REQUEST['pmpro_advancedsettings_nonce'] ) &&  ! check_admin_referer( 'savesettings', 'pmpro_advancedsettings_nonce' ) ) 
-		) {
+	// Only load this function if the PMPro Advanced Settings page is being loaded and nonce passes.
+	$is_settings_page = ! empty( $_REQUEST['page'] ) && $_REQUEST['page'] === 'pmpro-advancedsettings';
+	$nonce_valid =  ! empty( $_REQUEST['pmpro_advancedsettings_nonce'] ) && check_admin_referer( 'savesettings', 'pmpro_advancedsettings_nonce' );
+	if ( ! $is_settings_page && ! $nonce_valid ) {
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Google Maps API key is tested to check if it's valid or not upon save.

### How to test the changes in this Pull Request:

1. Navigate to Memberships > Settings > Advanced 
2. Enter in a Google Maps API key 
3. The status should show correctly

Before:

`API Key Status:`

After

`API Key Status: REQUEST_DENIED The provided API key is invalid.`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
