### PR TITLE
Throw an error when geocoding fails in the Edit Member Panel

### DIFF
--- a/includes/google-maps/includes/functions.php
+++ b/includes/google-maps/includes/functions.php
@@ -371,8 +371,9 @@ function pmpromd_save_marker_location_for_user( $user_id = false ) {
 				delete_user_meta( $user_id, 'pmpromd_pin_location' );
 			}
         } else {
+			// The $coordinates is not an array, most likely an error message set in the pmpromd_geocode_map_address function.
 			global $pmpro_msg, $pmpro_msgt;
-			$pmpro_msg = sprintf( esc_html__( 'There was an error with the Google Maps API: %s', 'pmpro-member-directory' ), esc_html( $coordinates ) );
+			$pmpro_msg = sprintf( esc_html__( 'There was an error with the Google Maps API: %s', 'pmpro-member-directory' ), $coordinates );
 			$pmpro_msgt = 'pmpro_error';
 		}
 

--- a/includes/google-maps/includes/functions.php
+++ b/includes/google-maps/includes/functions.php
@@ -369,8 +369,12 @@ function pmpromd_save_marker_location_for_user( $user_id = false ) {
             } else {
                 //Cleanup pin location
 				delete_user_meta( $user_id, 'pmpromd_pin_location' );
-            }
-        }
+			}
+        } else {
+			global $pmpro_msg, $pmpro_msgt;
+			$pmpro_msg = sprintf( esc_html__( 'There was an error with the Google Maps API: %s', 'pmpro-member-directory' ), esc_html( $coordinates ) );
+			$pmpro_msgt = 'pmpro_error';
+		}
 
     } else {
         //Cleanup pin location
@@ -427,6 +431,9 @@ function pmpromd_get_member_address( $user_id = false ) {
  */
 function pmpromd_geocode_map_address( $addr_array, $morder = false, $return_body = false ) {
 
+	// Remove the optin value from the address array as we don't need to send it to Google.
+	unset( $addr_array['optin'] );
+
 	// Turn the address array into a string for geocoding.
 	$address_string = implode( ", ", array_filter( $addr_array ) );
 
@@ -466,8 +473,7 @@ function pmpromd_geocode_map_address( $addr_array, $morder = false, $return_body
 			}
 
 		} else {
-			// pmpromm_report_geocode_api_error( $request_body );
-			$geocoded_data = false;
+			$geocoded_data = isset( $request_body->error_message ) ? $request_body->error_message : false;
 		}
 
 	}

--- a/includes/google-maps/includes/functions.php
+++ b/includes/google-maps/includes/functions.php
@@ -373,7 +373,7 @@ function pmpromd_save_marker_location_for_user( $user_id = false ) {
         } else {
 			// The $coordinates is not an array, most likely an error message set in the pmpromd_geocode_map_address function.
 			global $pmpro_msg, $pmpro_msgt;
-			$pmpro_msg = sprintf( esc_html__( 'There was an error with the Google Maps API: %s', 'pmpro-member-directory' ), $coordinates );
+			$pmpro_msg = sprintf( esc_html__( 'There was an error with the Google Maps API: %s', 'pmpro-member-directory' ), esc_html( $coordinates ) );
 			$pmpro_msgt = 'pmpro_error';
 		}
 
@@ -474,7 +474,7 @@ function pmpromd_geocode_map_address( $addr_array, $morder = false, $return_body
 			}
 
 		} else {
-			$geocoded_data = isset( $request_body->error_message ) ? $request_body->error_message : false;
+			$geocoded_data = isset( $request_body->error_message ) ? sanitize_text_field( $request_body->error_message ) : false;
 		}
 
 	}


### PR DESCRIPTION
* ENHANCEMENT: Throws an error warning when trying to geocode but geocoding fails from the Edit Member Panel.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

Return the "raw" human readable error message from Google Maps API.
<img width="2372" height="265" alt="Screenshot 2025-10-14 at 11 51 46" src="https://github.com/user-attachments/assets/baa27bbf-5841-42a6-b5c5-b98c88521623" />
