### PR TITLE
Fix a warning if the user object doesn't exist

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -560,7 +560,7 @@ function pmpromd_prepare_elements_array( $elements ) {
 function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 
 	// No user object, return an empty result instead.
-	if ( empty( $pu ) || ! is_object( $pu ) ) {
+	if ( ! ( $pu instanceof WP_User ) ) {
 		return '';
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -559,7 +559,7 @@ function pmpromd_prepare_elements_array( $elements ) {
  */
 function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 
-	// No user object, return an emptry result instead.
+	// No user object, return an empty result instead.
 	if ( empty( $pu ) || ! is_object( $pu ) ) {
 		return '';
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -558,6 +558,12 @@ function pmpromd_prepare_elements_array( $elements ) {
  * Get the value of a specific element from a string of HTML.
  */
 function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
+
+	// No user object, return an emptry result instead.
+	if ( empty( $pu ) || ! is_object( $pu ) ) {
+		return '';
+	}
+
 	// Initialize the value.
 	$value = '';
 

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -47,7 +47,7 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 	$pu = pmpromd_get_user( $user_id );
 
 	// If we're unable to get a user, show a message (to admins).
-	if ( empty( $pu ) || ! is_object( $pu ) ) {
+	if ( ! ( $pu instanceof WP_User ) ) {
 		$member_not_found = esc_html__( 'Unable to retrieve member profile.', 'pmpro-member-directory' );
 		if ( $directory_url ) {
 			$member_not_found .= ' <a href="' . esc_url( $directory_url ) . '">' . esc_html__( 'Go back to Directory', 'pmpro-member-directory' ) . '</a>';

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -46,6 +46,17 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 	// Get the user for this profile.
 	$pu = pmpromd_get_user( $user_id );
 
+	// If we're unable to get a user, show a message (to admins).
+	if ( empty( $pu ) || ! is_object( $pu ) ) {
+		$member_not_found = esc_html__( 'Unable to retrieve member profile.', 'pmpro-member-directory' );
+		if ( $directory_url ) {
+			$member_not_found .= ' <a href="' . esc_url( $directory_url ) . '">' . esc_html__( 'Go back to Directory', 'pmpro-member-directory' ) . '</a>';
+		} else {
+			$member_not_found .= ' ' . esc_html__( 'Please contact the site administrator for assistance.', 'pmpro-member-directory' );
+		}
+		return $member_not_found;
+	}
+
 	// Did they use level instead of levels?
 	if ( empty( $levels ) && ! empty( $level ) ) {
 		$levels = $level;

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -46,7 +46,8 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 	// Get the user for this profile.
 	$pu = pmpromd_get_user( $user_id );
 
-	// If we're unable to get a user, show a message (to admins).
+	// If we're unable to get a user, show a message.
+	// Note: this will only ever reach here if the shortcode is on a page that isn't the assigned profile page.
 	if ( ! ( $pu instanceof WP_User ) ) {
 		$member_not_found = esc_html__( 'Unable to retrieve member profile.', 'pmpro-member-directory' );
 		if ( $directory_url ) {


### PR DESCRIPTION
* BUG FIX: Fixes a warning in some cases where trying to get the value of a user that no longer exists.

This PR ensures that the $user object exists and doesn't try to get on erroneous requests.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
