### PR TITLE
Fix date values being wrong

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -713,6 +713,9 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 
 		// Format the date fields.
 		if ( in_array( $element, $date_fields ) && ! empty( $value ) ) {
+			if ( ! is_numeric( $value ) ) {
+				$value = strtotime( $value );
+			}
 			$value = date_i18n( get_option('date_format'), $value );
 		}
 


### PR DESCRIPTION
* BUG FIX: Fixes an issue where outputting user_registered values would show today's date. Cast non-numeric date values back to integer to get the translatable date - this should fix other potential date issues.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?
