### PR TITLE
Fixing warning for null parameter. Map function will now return an empty string.

### DIFF
--- a/includes/google-maps/includes/functions.php
+++ b/includes/google-maps/includes/functions.php
@@ -27,13 +27,13 @@ function pmpromd_show_google_map( $attributes, $members ) {
 
 	// Only show the map if the 'show_map' attribute is set to true.
 	if ( $attributes['show_map'] === false ) {
-		return;
+		return '';
 	}
 
 	// Make sure we have the Maps API key, including the deprecated one.
 	$maps_api_key = get_option( 'pmpro_pmpromd_maps_api_key' ) ?? get_option( 'pmpro_pmpromm_maps_api_key' );
 	if ( empty( $maps_api_key ) ) {
-		return;
+		return '';
 	}
 
 	// Extract the array $attributes so we can use them directly without doing $attributes['key'] all the time.

--- a/templates/profile.php
+++ b/templates/profile.php
@@ -182,8 +182,6 @@ function pmpromd_profile_shortcode( $atts, $content=null, $code="" ) {
 				echo wp_kses_post( pmpromd_show_google_map( $shortcode_atts, $pu ) );
 			?>
 
-		
-
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 				<?php
 					foreach ( $elements_array as $element ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The `pmpromd_show_google_map` function has two early returns of an empty / null that were being passed to the wp_kses_post function in shortcode. We're now returning an empty string to avoid the warning `preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated)`.

An alternative would be to check if the return of the `pmpromd_show_google_map` is not null before sanitizing and echoing, but this seems cleaner overall.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed warning when map function returned a null value.