### PR TITLE
Only enqueue editor scripts when editing a page or post

### DIFF
--- a/blocks/dist/directory/block.php
+++ b/blocks/dist/directory/block.php
@@ -9,17 +9,29 @@ if ( ! function_exists( 'register_block_type' ) ) {
 
 // Register block type.
 function pmpromd_register_directory_block() {
-
-	wp_register_script( 
-		'pmpromd-directory-block', 
-		plugins_url( 'block.build.js', __FILE__ ), 
-		array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api', 'wp-editor', 'pmpro_admin' )
-	);
-
 	register_block_type( 'pmpro-member-directory/directory', array(
 		'editor_script' => 'pmpromd-directory-block',
 		'render_callback' => 'pmpromd_shortcode'
 	) );
 
 }
-add_action( 'init', 'pmpromd_register_directory_block' );
+add_action( 'enqueue_block_editor_assets', 'pmpromd_register_directory_block' );
+
+/**
+ * Register block editor scripts and styles.
+ *
+ * @since TBD
+ */
+function pmpromd_enqueue_directory_block_editor_assets() {
+	// Only load on post and page edit screens.
+	if ( ! in_array( get_post_type(), array( 'page', 'post' ) ) ) {
+		return;
+	}
+
+	wp_register_script( 
+		'pmpromd-directory-block', 
+		plugins_url( 'block.build.js', __FILE__ ), 
+		array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api', 'wp-editor', 'pmpro_admin' )
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'pmpromd_enqueue_directory_block_editor_assets' );

--- a/blocks/dist/profile/block.php
+++ b/blocks/dist/profile/block.php
@@ -13,17 +13,28 @@ if ( ! function_exists( 'register_block_type' ) ) {
 
 // Register block type.
 function pmpromd_register_profile_block() {
+	register_block_type( 'pmpro-member-directory/profile', array(
+		'editor_script' => 'pmpromd-profile-block',
+		'render_callback' => 'pmpromd_profile_shortcode'
+	) );
+}
+add_action( 'init', 'pmpromd_register_profile_block' );	
+
+/**
+ * Register block editor scripts and styles.
+ *
+ * @since TBD
+ */
+function pmpromd_enqueue_profile_block_editor_assets() {
+	// Only load on post and page edit screens.
+	if ( ! in_array( get_post_type(), array( 'page', 'post' ) ) ) {
+		return;
+	}
 
 	wp_register_script( 
 		'pmpromd-profile-block', 
 		plugins_url( 'block.build.js', __FILE__ ), 
 		array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api', 'wp-editor', 'pmpro_admin' )
 	);
-
-	register_block_type( 'pmpro-member-directory/profile', array(
-		'editor_script' => 'pmpromd-profile-block',
-		'render_callback' => 'pmpromd_profile_shortcode'
-	) );
-
 }
-add_action( 'init', 'pmpromd_register_profile_block' );	
+add_action( 'enqueue_block_editor_assets', 'pmpromd_enqueue_profile_block_editor_assets' );

--- a/blocks/src/directory/block.php
+++ b/blocks/src/directory/block.php
@@ -9,17 +9,29 @@ if ( ! function_exists( 'register_block_type' ) ) {
 
 // Register block type.
 function pmpromd_register_directory_block() {
-
-	wp_register_script( 
-		'pmpromd-directory-block', 
-		plugins_url( 'block.build.js', __FILE__ ), 
-		array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api', 'wp-editor', 'pmpro_admin' )
-	);
-
 	register_block_type( 'pmpro-member-directory/directory', array(
 		'editor_script' => 'pmpromd-directory-block',
 		'render_callback' => 'pmpromd_shortcode'
 	) );
 
 }
-add_action( 'init', 'pmpromd_register_directory_block' );
+add_action( 'enqueue_block_editor_assets', 'pmpromd_register_directory_block' );
+
+/**
+ * Register block editor scripts and styles.
+ *
+ * @since TBD
+ */
+function pmpromd_enqueue_directory_block_editor_assets() {
+	// Only load on post and page edit screens.
+	if ( ! in_array( get_post_type(), array( 'page', 'post' ) ) ) {
+		return;
+	}
+
+	wp_register_script( 
+		'pmpromd-directory-block', 
+		plugins_url( 'block.build.js', __FILE__ ), 
+		array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api', 'wp-editor', 'pmpro_admin' )
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'pmpromd_enqueue_directory_block_editor_assets' );

--- a/blocks/src/profile/block.php
+++ b/blocks/src/profile/block.php
@@ -13,17 +13,28 @@ if ( ! function_exists( 'register_block_type' ) ) {
 
 // Register block type.
 function pmpromd_register_profile_block() {
+	register_block_type( 'pmpro-member-directory/profile', array(
+		'editor_script' => 'pmpromd-profile-block',
+		'render_callback' => 'pmpromd_profile_shortcode'
+	) );
+}
+add_action( 'init', 'pmpromd_register_profile_block' );	
+
+/**
+ * Register block editor scripts and styles.
+ *
+ * @since TBD
+ */
+function pmpromd_enqueue_profile_block_editor_assets() {
+	// Only load on post and page edit screens.
+	if ( ! in_array( get_post_type(), array( 'page', 'post' ) ) ) {
+		return;
+	}
 
 	wp_register_script( 
 		'pmpromd-profile-block', 
 		plugins_url( 'block.build.js', __FILE__ ), 
 		array( 'wp-i18n', 'wp-element', 'wp-blocks', 'wp-components', 'wp-api', 'wp-editor', 'pmpro_admin' )
 	);
-
-	register_block_type( 'pmpro-member-directory/profile', array(
-		'editor_script' => 'pmpromd-profile-block',
-		'render_callback' => 'pmpromd_profile_shortcode'
-	) );
-
 }
-add_action( 'init', 'pmpromd_register_profile_block' );	
+add_action( 'enqueue_block_editor_assets', 'pmpromd_enqueue_profile_block_editor_assets' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes the following error message by only enqueuing editor scripts when editing a post or page (not widgets):
`Function wp_enqueue_script() was called incorrectly. "wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets). (This message was added in version 5.8.0.)`

When testing, `npm run build` must be run to see changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
