### PR TITLE
Fix block-related browser warnings

### DIFF
--- a/blocks/src/components/extra-fields/extra-fields.js
+++ b/blocks/src/components/extra-fields/extra-fields.js
@@ -13,14 +13,14 @@ function ShowExtraFields( { fields, type } ) {
         
             if ( type === 'profile' ) {
                 custom_fields.push(
-                    <div className='pmpro-member-profile-wrapper'>
+                    <div key={index} className='pmpro-member-profile-wrapper'>
                     <span className='pmpro-member-profile-subheading'>{field_data[0]}</span><br/>
                     <span className='pmpro-member-profile-content'>{field_data[1]}</span>
                     </div>
                 );
             } else {
                 custom_fields.push(
-                    <div className='pmpro-member-profile-wrapper'>
+                    <div key={index} className='pmpro-member-profile-wrapper'>
                     <span className='pmpro-member-profile-subheading'>{field_data[0]}: </span><span className='pmpro-member-profile-content'>{field_data[1]}</span>
                     </div>
                 );

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -51,7 +51,7 @@ export default registerBlockType(
           },
           levels: {
             type: 'array',
-            default: ''
+            default: []
           },
           show_avatar: {
             type: 'boolean',

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -173,7 +173,7 @@ export default registerBlockType(
           }
 
           return [
-            isSelected && <InspectorControls>
+            isSelected && <InspectorControls key="controls">
               
               <PanelBody
                 title={ __('Display Options', 'pmpro-member-directory' ) }
@@ -363,7 +363,7 @@ export default registerBlockType(
                 />
               </PanelBody>
             </InspectorControls>,
-              <div className={ className } style={{ fontFamily: 'arial', fontSize: '14px' } }>
+              <div key="preview" className={ className } style={{ fontFamily: 'arial', fontSize: '14px' } }>
                 <div className={ !show_map ? "hidden" : "" }>
                   <img src={ require('../components/icons/google-maps-placeholder.png') } alt="Map Placeholder" />
                 </div>

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -177,6 +177,8 @@ export default registerBlockType(
                 title={ __('Display Options', 'pmpro-member-directory' ) }
               >
                 <SelectControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   multiple
                   label={ __( 'Select levels', 'pmpro-member-directory' ) }
                   help={ __('List of level IDs that allow profiles. Default: All', 'pmpro-member-directory') }
@@ -185,7 +187,9 @@ export default registerBlockType(
                   options={ all_levels }
                 />
 
-                <SelectControl 
+                <SelectControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="Layout"
                   value={ layout }
                   onChange={ layout => { setAttributes( { layout } ) } }
@@ -198,44 +202,52 @@ export default registerBlockType(
                   ]}
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Search'
                   checked={ show_search }
                   onChange={ show_search => { setAttributes( { show_search } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label="Show Avatar"
                   checked={ show_avatar }
                   onChange={ show_avatar => { setAttributes( { show_avatar } ) } }
                 />
              
-                <TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="Avatar Size"
                   value={ avatar_size }
                   className={ !show_avatar ? "hidden" : "" }
                   onChange={ avatar_size => { setAttributes( { avatar_size } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Level'
                   checked={ show_level }
                   onChange={ show_level => { setAttributes( { show_level } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Email Address'
                   checked={ show_email }
                   onChange={ show_email => { setAttributes( { show_email } ) } }
                 />
                 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Start Date'
                   checked={ show_startdate }
                   onChange={ show_startdate => { setAttributes( { show_startdate } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label="Show Link"
                   checked={ link }
                   onChange={ link => { setAttributes( { link } ) } }
@@ -244,40 +256,51 @@ export default registerBlockType(
 
 			  <PanelBody title={ __( 'Map Options', 'pmpro-member-directory' ) } >
 				<CheckboxControl
+				  __nextHasNoMarginBottom
 				  label={ __( 'Show Map', 'pmpro-member-directory' ) }
 				  checked={ show_map }
 				  onChange={ show_map => { setAttributes( { show_map } ) } }
 				/>
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Map Zoom', 'pmpro-member-directory' ) }
                   value={ map_zoom }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_zoom => { setAttributes( { map_zoom } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Map Height', 'pmpro-member-directory' ) }
                   value={ map_height }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_height => { setAttributes( { map_height } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   label={ __( 'Map Width', 'pmpro-member-directory' ) }
                   value={ map_width }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_width => { setAttributes( { map_width } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Max Zoom Level', 'pmpro-member-directory' ) }
                   value={ map_max_zoom }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_max_zoom => { setAttributes( { map_max_zoom } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Infowindow Width', 'pmpro-member-directory' ) }
                   value={ map_infowindow_width }
                   className={ !show_map ? "hidden" : "" }
@@ -288,7 +311,8 @@ export default registerBlockType(
               <PanelBody
                 title={ __( 'Extra Fields', 'pmpro-member-directory' ) }
               >
-                <TextareaControl 
+                <TextareaControl
+                  __nextHasNoMarginBottom 
                   label="Fields"
                   value={ fields }
                   onChange={ fields => { setAttributes( { fields } ) } }
@@ -299,7 +323,9 @@ export default registerBlockType(
               <PanelBody
                 title={ __( 'Filtering Options', 'pmpro-member-directory' )  }
               >
-                <SelectControl 
+                <SelectControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="Order By"
                   value={ order_by }
                   onChange={ order_by => { setAttributes( { order_by } ) } }
@@ -314,7 +340,9 @@ export default registerBlockType(
                   ]}
                 />
 
-                <SelectControl 
+                <SelectControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="Order"
                   value={ order }
                   onChange={ order => { setAttributes( { order } ) } }
@@ -324,7 +352,9 @@ export default registerBlockType(
                   ]}
                 />
 
-                <TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="Limit"
                   value={ limit }
                   onChange={ limit => { setAttributes( { limit } ) } }

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -101,7 +101,8 @@ export default registerBlockType(
             type: 'string',
           },
           limit: {
-            type: 'string'
+            type: 'string',
+            default: '15'
           },
           link: {
             type: 'boolean',

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -164,10 +164,12 @@ export default registerBlockType(
            if ( !levels.length ) {
             return null;
            }
-            return [
-            <span className="pmpro-member-profile-levels" style={{ fontSize: '12px' }}>{ __( 'Levels Selected: ',  'pmpro-member-directory' ) + levels }</span>,
-            <br/>
-            ]
+            return (
+             <>
+              <span className="pmpro-member-profile-levels" style={{ fontSize: '12px' }}>{ __( 'Levels Selected: ',  'pmpro-member-directory' ) + levels }</span>
+              <br/>
+             </>
+            )
           }
 
           return [

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -121,46 +121,43 @@ export default registerBlockType(
                 className, isSelected, setAttributes } = props;
 
           function show_layout_selected() {
-            const layout_return = [];
             if ( layout == 'div' ) {
-              layout_return.push(
+              return (
                 <DivLayout 
                     attributes={props.attributes}             
                   />
               );
             } else if( layout == 'table' ) {
-              layout_return.push(
+              return (
                 <TableLayout
                   attributes={props.attributes}
                 />
               );
             } else if( layout == '2col' ) {
-              layout_return.push( 
+              return ( 
                 <Col2
                   attributes={props.attributes}
                 /> 
                 );
             } else if( layout == '3col' ) {
-              layout_return.push( 
+              return ( 
                 <Col3
                   attributes={props.attributes}
                 /> 
                 );
             } else if( layout == '4col' ) {
-              layout_return.push(
+              return (
                 <Col4
                   attributes={props.attributes}
                 />
               );
             } else {
-              layout_return.push(
+              return (
                 <DivLayout 
                     attributes={props.attributes}             
                   />
               )
             }
-
-            return layout_return;
           }
 
           function show_levels_selected() {

--- a/blocks/src/directory/block.js
+++ b/blocks/src/directory/block.js
@@ -20,7 +20,7 @@ const {
 
 const {
   InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 const all_levels = pmpro.all_level_values_and_labels;
 

--- a/blocks/src/directory/templates/table.js
+++ b/blocks/src/directory/templates/table.js
@@ -12,13 +12,15 @@ class TableLayout extends Component {
         return (
             <table className="pmpro-table" style={{ width: '100%', border: '1px solid black' }}>
                 <thead>
-                    <th className={ show_avatar ? '' : 'hidden'}>{ __( 'Avatar', 'pmpro-member-directory' ) }</th>
-                    <th>{ __( 'Member', 'pmpro-member-directory' ) }</th>
-                    <th className={ show_email ? '' : 'hidden' }>{ __( 'Email Address', 'pmpro-member-directory' ) }</th>
-                    <th className={ fields ? '' : 'hidden'}>{ __( 'More Information', 'pmpro-member-directory' ) }</th>
-                    <th className={ show_level ? '' : 'hidden' }>{ __( 'Level', 'pmpro-member-directory' ) }</th>
-                    <th className={ show_startdate ? '' : 'hidden' }>{ __( 'Start Date', 'pmpro-member-directory' ) }</th>
-                    <th className={ link ? '' : 'hidden' }>&nbsp;</th>
+                    <tr>
+                        <th className={ show_avatar ? '' : 'hidden'}>{ __( 'Avatar', 'pmpro-member-directory' ) }</th>
+                        <th>{ __( 'Member', 'pmpro-member-directory' ) }</th>
+                        <th className={ show_email ? '' : 'hidden' }>{ __( 'Email Address', 'pmpro-member-directory' ) }</th>
+                        <th className={ fields ? '' : 'hidden'}>{ __( 'More Information', 'pmpro-member-directory' ) }</th>
+                        <th className={ show_level ? '' : 'hidden' }>{ __( 'Level', 'pmpro-member-directory' ) }</th>
+                        <th className={ show_startdate ? '' : 'hidden' }>{ __( 'Start Date', 'pmpro-member-directory' ) }</th>
+                        <th className={ link ? '' : 'hidden' }>&nbsp;</th>
+                    </tr>
                 </thead>
                 <tbody>
                     <tr>

--- a/blocks/src/profile/block.js
+++ b/blocks/src/profile/block.js
@@ -50,7 +50,7 @@ export default registerBlockType(
           },
           show_bio: {
             type: 'boolean',
-            default: 'true'
+            default: true
           },
           show_email: {
             type: 'boolean',

--- a/blocks/src/profile/block.js
+++ b/blocks/src/profile/block.js
@@ -120,68 +120,81 @@ export default registerBlockType(
               >
 
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Search'
                   checked={ show_search }
                   onChange={ show_search => { setAttributes( { show_search } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label="Show Avatar"
                   checked={ show_avatar }
                   onChange={ show_avatar => { setAttributes( { show_avatar } ) } }
                 />
              
-                <TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="Avatar Size"
                   value={ avatar_size }
                   className={ !show_avatar ? "hidden" : "" }
                   onChange={ avatar_size => { setAttributes( { avatar_size } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Bio'
                   checked={ show_bio }
                   onChange={ show_bio => { setAttributes( { show_bio } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Level'
                   checked={ show_level }
                   onChange={ show_level => { setAttributes( { show_level } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Email Address'
                   checked={ show_email }
                   onChange={ show_email => { setAttributes( { show_email } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Name'
                   checked={ show_name }
                   onChange={ show_name => { setAttributes( { show_name } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Start Date'
                   checked={ show_startdate }
                   onChange={ show_startdate => { setAttributes( { show_startdate } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Billing (deprecated)'
                   checked={ show_billing }
                   onChange={ show_billing => { setAttributes( { show_billing } ) } }
                 />
 
-                <CheckboxControl 
+                <CheckboxControl
+                  __nextHasNoMarginBottom 
                   label='Show Phone (deprecated)'
                   checked={ show_phone }
                   onChange={ show_phone => { setAttributes( { show_phone } ) } }
                 />
 
-                <TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label="User ID"
                   value={ user_id }
                   onChange={ user_id => { setAttributes( { user_id } ) } }
@@ -192,40 +205,51 @@ export default registerBlockType(
 
 			   <PanelBody title={ __( 'Map Options', 'pmpro-member-directory' ) } >
 				<CheckboxControl
+				  __nextHasNoMarginBottom
 				  label={ __( 'Show Map', 'pmpro-member-directory' ) }
 				  checked={ show_map }
 				  onChange={ show_map => { setAttributes( { show_map } ) } }
 				/>
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Map Zoom', 'pmpro-member-directory' ) }
                   value={ map_zoom }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_zoom => { setAttributes( { map_zoom } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Map Height', 'pmpro-member-directory' ) }
                   value={ map_height }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_height => { setAttributes( { map_height } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Map Width', 'pmpro-member-directory' ) }
                   value={ map_width }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_width => { setAttributes( { map_width } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Max Zoom Level', 'pmpro-member-directory' ) }
                   value={ map_max_zoom }
                   className={ !show_map ? "hidden" : "" }
                   onChange={ map_max_zoom => { setAttributes( { map_max_zoom } ) } }
                 />
 
-				<TextControl 
+                <TextControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom 
                   label={ __( 'Infowindow Width', 'pmpro-member-directory' ) }
                   value={ map_infowindow_width }
                   className={ !show_map ? "hidden" : "" }
@@ -236,7 +260,8 @@ export default registerBlockType(
               <PanelBody
                 title={ __('Extra Fields', 'pmpro-member-directory' ) }
               >
-                <TextareaControl 
+                <TextareaControl
+                  __nextHasNoMarginBottom 
                   label="Fields"
                   value={ fields }
                   onChange={ fields => { setAttributes( { fields } ) } }

--- a/blocks/src/profile/block.js
+++ b/blocks/src/profile/block.js
@@ -17,7 +17,7 @@ const {
 
 const {
   InspectorControls,
-} = wp.editor;
+} = wp.blockEditor;
 
 export default registerBlockType(
     'pmpro-member-directory/profile',

--- a/blocks/src/profile/block.js
+++ b/blocks/src/profile/block.js
@@ -114,7 +114,7 @@ export default registerBlockType(
           className, isSelected, setAttributes } = props;
 
           return [
-            isSelected && <InspectorControls>
+            isSelected && <InspectorControls key="controls">
               <PanelBody
                 title={ __( 'Display Settings', 'pmpro-member-directory' ) }
               >
@@ -269,7 +269,7 @@ export default registerBlockType(
                 />
               </PanelBody>
               </InspectorControls>,
-              <div className={ className } style={{ fontFamily: 'arial', fontSize: '14px' } }>
+              <div key="preview" className={ className } style={{ fontFamily: 'arial', fontSize: '14px' } }>
 				<div className={ !show_map ? "hidden" : "" }>
                   <img src={ require('../components/icons/google-maps-placeholder.png') } alt="Map Placeholder" />
                 </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ config.plugins.push(
 	new CopyPlugin({
 		patterns: [
 			{
-				from: path.resolve(process.cwd(), "blocks", "src", "**", "*.php"),
+				from: "**/*.php",
 				to: path.resolve(process.cwd(), "blocks", "dist"),
 				context: path.resolve(process.cwd(), "blocks", "src")
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Resolves a build error caused by an invalid path in _webpack.config.js_.
Updates block components to use new WP default spacing and sizing.
Resolves various console warnings and errors associated with the Directory and Profile blocks.

### How to test the changes in this Pull Request:
Adding the Add On's blocks to pages and modifying field values in the blocks' sidebars does not trigger any warnings/errors after this PR is applied. Functionality is unaffected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
