### PR TITLE
Fixing the default country shown for user map address fields

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -113,9 +113,11 @@ function pmpromd_add_user_fields() {
 		// Get the list of countries from PMPro core.
 		if ( function_exists( 'pmpro_get_countries' ) ) {
 			$countries = pmpro_get_countries();
+			$default_country = pmpro_get_default_country();
 		} else {
-			global $pmpro_countries;
+			global $pmpro_countries, $pmpro_default_country;
 			$countries = $pmpro_countries;
+			$default_country = $pmpro_default_country;
 		}
 
 		// Generate this with the PMPro Country field.
@@ -130,7 +132,7 @@ function pmpromd_add_user_fields() {
 					'required' => false,
 					'options' => $countries,
 					'class' => 'pmpromd-map-address-field',
-					'default' => $pmpro_default_country
+					'value' => $default_country
 				)
 			)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The map address field would previously always default to "Afghanistan" instead of the default country set in PMPro.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set a Google Maps API key in advanced settings to get the address user fields to show
2. View the address user fields for a new user
3. See that the default is Afghanistan before the PR, but the site default afterwards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
