### PR TITLE
Fix so null values are removed before returning the nearest enddate or oldest startdate for a member

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -620,6 +620,14 @@ function pmpromd_get_display_value( $element, $pu, $displayed_levels = null ) {
 			$start_dates = array_column( $all_levels_to_display, 'startdate' );
 			$end_dates = array_column( $all_levels_to_display, 'enddate' );
 
+			// Only use real start and end dates (ignore null/empty values).
+			$start_dates = array_filter( $start_dates, function( $startdate ) {
+				return ! empty( $startdate );
+			} );
+			$end_dates = array_filter( $end_dates, function( $enddate ) {
+				return ! empty( $enddate );
+			} );
+
 			$startdate = ! empty( $start_dates ) ? min( $start_dates ) : null;
 			$enddate = ! empty( $end_dates ) ? min( $end_dates ) : null;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR prevents `null`/empty start and end date values from affecting the calculated `startdate` and `enddate` shown for members with multiple membership levels.

Start and end dates are now filtered to include only real values before calculating the oldest start date and the soonest end date.

### How to test the changes in this Pull Request:

1. Create (or use) a test user with **multiple membership levels**, including at least one **recurring level that never expires**.
2. View the Member Directory output where the member’s start/end dates are displayed.
3. Confirm the member’s displayed **end date** is the **soonest upcoming valid expiration date**, and is not blank/null due to a never-expiring level (has active subscription).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Fixes member start/end date calculations when some membership levels do not have an expiration date.
