### PR TITLE
Removing use of SQL_CALC_FOUND_ROWS modifier

### DIFF
--- a/templates/directory.php
+++ b/templates/directory.php
@@ -82,7 +82,7 @@ function pmpromd_shortcode( $atts, $content=null, $code="" ) {
 	$sql_parts = array();
 
 	$sql_parts['SELECT'] = "
-	SELECT SQL_CALC_FOUND_ROWS 
+	SELECT 
 		u.ID,
 		u.user_nicename,
 		umf.meta_value AS first_name, 
@@ -154,7 +154,23 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 $sqlQuery = apply_filters( 'pmpro_member_directory_sql', $sqlQuery, $levels, $s, $pn, $limit, $start, $end, $order_by, $order );
 
 	$theusers = $wpdb->get_results($sqlQuery);
-	$totalrows = $wpdb->get_var("SELECT FOUND_ROWS() as found_rows");
+
+	// Build the count query.
+	// Replace SELECT list with COUNT(DISTINCT u.ID).
+	$count_sql = preg_replace(
+		'/^\s*SELECT\s+[\s\S]*?\s+FROM\s+/i',
+		'SELECT COUNT( DISTINCT u.ID ) FROM ',
+		$sqlQuery,
+		1
+	);
+
+	// Remove everything from GROUP BY onward (GROUP, ORDER, LIMIT, etc.).
+	$count_sql = preg_replace(
+		'/\s+GROUP\s+BY\s+[\s\S]*$/i',
+		'',
+		$count_sql
+	);
+	$totalrows = (int) $wpdb->get_var( $count_sql );
 
 	// Update end to match totalrows if total rows is small.
 	if ( $totalrows < $end )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-member-directory/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-member-directory/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The SQL_CALC_FOUND_ROWS SELECT modifier is deprecated and will be removed in a future release. This PR removes instances of us using that modifier.

Note that this PR derives the "count" query by adjusting the "SELECT" clause of the original query and the rest of the query past "GROUP BY" to remove the group by, order, and limit. This is not technically the correct way to make this change as the query could break with nested queries. Instead, something like `SELECT COUNT(*) FROM ( $sql )` would work 100% of the time with the downside of being much less performant. Due to the performance issues, however, we are going with the less robust but more performant approach as it should work on the vast majority of uses of the `pmpro_member_directory_sql` filter. If this is an issue down the line though, maybe we can have both approaches in place and a filter to switch from our performant approach to the more robust one for sites that need it.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
