### PR TITLE
Cache directory query results to avoid heavy joins on every render

### DIFF
--- a/includes/cache.php
+++ b/includes/cache.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Member Directory query result caching.
+ *
+ * Caches the user list + total count for [pmpro_member_directory] queries
+ * keyed by the final SQL string. Invalidated by user / membership lifecycle
+ * hooks via a version counter so stale entries fall out naturally on TTL.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'PMPROMD_CACHE_GROUP', 'pmpro_member_directory' );
+
+/**
+ * Get the current cache version. Incrementing this invalidates every cached
+ * directory query in one shot. Stored in a non-autoloaded option so it
+ * survives an object-cache flush.
+ *
+ * @return int
+ */
+function pmpromd_get_cache_version() {
+	$version = wp_cache_get( 'cache_version', PMPROMD_CACHE_GROUP );
+	if ( false === $version ) {
+		$version = (int) get_option( 'pmpromd_cache_version', 1 );
+		wp_cache_set( 'cache_version', $version, PMPROMD_CACHE_GROUP, HOUR_IN_SECONDS );
+	}
+	return (int) $version;
+}
+
+/**
+ * Bump the cache version, invalidating all cached query results.
+ *
+ * @return void
+ */
+function pmpromd_bump_cache_version() {
+	$version = pmpromd_get_cache_version() + 1;
+	update_option( 'pmpromd_cache_version', $version, false );
+	wp_cache_set( 'cache_version', $version, PMPROMD_CACHE_GROUP, HOUR_IN_SECONDS );
+}
+
+/**
+ * Build a cache key for a directory query. Hash includes the version counter
+ * so a bump invalidates every existing key in one operation.
+ *
+ * @param string $sql The final assembled SQL string.
+ * @return string
+ */
+function pmpromd_get_cache_key( $sql ) {
+	return 'query_' . md5( pmpromd_get_cache_version() . '|' . $sql );
+}
+
+/**
+ * Look up a cached result set for the given SQL.
+ *
+ * @param string $sql The final assembled SQL string.
+ * @return array|false { users: array, totalrows: int } on hit, false on miss or when caching is disabled.
+ */
+function pmpromd_get_cached_results( $sql ) {
+	/**
+	 * Filter: 'pmpro_member_directory_cache_enabled' - Toggle the query cache.
+	 *
+	 * @param bool $enabled True to read/write the cache, false to bypass.
+	 */
+	if ( ! apply_filters( 'pmpro_member_directory_cache_enabled', true ) ) {
+		return false;
+	}
+	return wp_cache_get( pmpromd_get_cache_key( $sql ), PMPROMD_CACHE_GROUP );
+}
+
+/**
+ * Store directory query results in cache.
+ *
+ * @param string $sql       The final assembled SQL string.
+ * @param array  $users     User result rows from $wpdb->get_results().
+ * @param int    $totalrows COUNT(DISTINCT u.ID) result.
+ * @return void
+ */
+function pmpromd_set_cached_results( $sql, $users, $totalrows ) {
+	if ( ! apply_filters( 'pmpro_member_directory_cache_enabled', true ) ) {
+		return;
+	}
+	/**
+	 * Filter: 'pmpro_member_directory_cache_ttl' - Cache lifetime in seconds.
+	 *
+	 * @param int $ttl Default 15 * MINUTE_IN_SECONDS.
+	 */
+	$ttl = (int) apply_filters( 'pmpro_member_directory_cache_ttl', 15 * MINUTE_IN_SECONDS );
+	wp_cache_set(
+		pmpromd_get_cache_key( $sql ),
+		array(
+			'users'     => $users,
+			'totalrows' => (int) $totalrows,
+		),
+		PMPROMD_CACHE_GROUP,
+		$ttl
+	);
+}
+
+/**
+ * Invalidate when a member's directory-relevant user meta changes.
+ *
+ * @param int    $meta_id    Meta row ID.
+ * @param int    $object_id  User ID.
+ * @param string $meta_key   Meta key being changed.
+ * @param mixed  $meta_value New value.
+ * @return void
+ */
+function pmpromd_maybe_bump_on_user_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
+	/**
+	 * Filter: 'pmpro_member_directory_watched_user_meta' - Meta keys that
+	 * should invalidate the directory cache when they change. Sites that
+	 * expose custom fields in the directory should add their keys here.
+	 *
+	 * @param array $watched Default: first_name, last_name, pmpromd_hide_directory, pmpromd_pin_location.
+	 */
+	$watched = apply_filters(
+		'pmpro_member_directory_watched_user_meta',
+		array( 'first_name', 'last_name', 'pmpromd_hide_directory', 'pmpromd_pin_location' )
+	);
+	if ( in_array( $meta_key, $watched, true ) ) {
+		pmpromd_bump_cache_version();
+	}
+}
+
+// User lifecycle invalidation.
+add_action( 'user_register',                       'pmpromd_bump_cache_version' );
+add_action( 'profile_update',                      'pmpromd_bump_cache_version' );
+add_action( 'deleted_user',                        'pmpromd_bump_cache_version' );
+add_action( 'pmpro_after_change_membership_level', 'pmpromd_bump_cache_version' );
+
+// Directory-relevant meta invalidation.
+add_action( 'added_user_meta',   'pmpromd_maybe_bump_on_user_meta', 10, 4 );
+add_action( 'updated_user_meta', 'pmpromd_maybe_bump_on_user_meta', 10, 4 );
+add_action( 'deleted_user_meta', 'pmpromd_maybe_bump_on_user_meta', 10, 4 );

--- a/pmpro-member-directory.php
+++ b/pmpro-member-directory.php
@@ -26,6 +26,7 @@ file_exists( $custom_profile_file ) ? require_once( $custom_profile_file ) : req
 // Includes
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/blocks/blocks.php');
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/admin.php' );
+require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/cache.php' );
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/deprecated.php' );
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/functions.php' );
 require_once( PMPRO_MEMBER_DIRECTORY_DIR . '/includes/search.php' );

--- a/templates/directory.php
+++ b/templates/directory.php
@@ -153,24 +153,37 @@ $sqlQuery = $sql_parts['SELECT'] . $sql_parts['JOIN'] . $sql_parts['WHERE'] . $s
 // Final filter on full SQL string
 $sqlQuery = apply_filters( 'pmpro_member_directory_sql', $sqlQuery, $levels, $s, $pn, $limit, $start, $end, $order_by, $order );
 
-	$theusers = $wpdb->get_results($sqlQuery);
+	// Check the query cache before hitting the database. Cache is keyed by the
+	// final SQL string, so distinct shortcode args / search / pagination /
+	// custom-filter combinations get distinct cache entries.
+	$cached = function_exists( 'pmpromd_get_cached_results' ) ? pmpromd_get_cached_results( $sqlQuery ) : false;
+	if ( is_array( $cached ) && isset( $cached['users'], $cached['totalrows'] ) ) {
+		$theusers  = $cached['users'];
+		$totalrows = (int) $cached['totalrows'];
+	} else {
+		$theusers = $wpdb->get_results($sqlQuery);
 
-	// Build the count query.
-	// Replace SELECT list with COUNT(DISTINCT u.ID).
-	$count_sql = preg_replace(
-		'/^\s*SELECT\s+[\s\S]*?\s+FROM\s+/i',
-		'SELECT COUNT( DISTINCT u.ID ) FROM ',
-		$sqlQuery,
-		1
-	);
+		// Build the count query.
+		// Replace SELECT list with COUNT(DISTINCT u.ID).
+		$count_sql = preg_replace(
+			'/^\s*SELECT\s+[\s\S]*?\s+FROM\s+/i',
+			'SELECT COUNT( DISTINCT u.ID ) FROM ',
+			$sqlQuery,
+			1
+		);
 
-	// Remove everything from GROUP BY onward (GROUP, ORDER, LIMIT, etc.).
-	$count_sql = preg_replace(
-		'/\s+GROUP\s+BY\s+[\s\S]*$/i',
-		'',
-		$count_sql
-	);
-	$totalrows = (int) $wpdb->get_var( $count_sql );
+		// Remove everything from GROUP BY onward (GROUP, ORDER, LIMIT, etc.).
+		$count_sql = preg_replace(
+			'/\s+GROUP\s+BY\s+[\s\S]*$/i',
+			'',
+			$count_sql
+		);
+		$totalrows = (int) $wpdb->get_var( $count_sql );
+
+		if ( function_exists( 'pmpromd_set_cached_results' ) ) {
+			pmpromd_set_cached_results( $sqlQuery, $theusers, $totalrows );
+		}
+	}
 
 	// Update end to match totalrows if total rows is small.
 	if ( $totalrows < $end )


### PR DESCRIPTION
## Summary

The `[pmpro_member_directory]` shortcode runs a `LEFT JOIN` across `wp_users`, `wp_pmpro_memberships_users`, and four `wp_usermeta` keys, then a follow-up `COUNT(DISTINCT u.ID)`. On directories with thousands of members, those joins dominate every shortcode render.

The acute case is Rank Math's image sitemap: it calls `do_blocks( \$post->post_content )` on every page in the post/page sitemap to scan for images, and any page that embeds the directory shortcode runs the full query each time the sitemap is regenerated. We hit this on a hosted customer site (~4,300 members, ~8 pages embedding the directory) — checkout requests landing during a sitemap regen saw 256M PHP fatals due to the resulting CPU/memory spike.

## What this changes

- New `includes/cache.php` with a thin `wp_cache_*` layer keyed by the final assembled SQL string.
- `templates/directory.php`: check the cache before `\$wpdb->get_results()`; on miss, run both queries and store them together.
- Invalidation via a version-counter bumped on:
  - `user_register`, `profile_update`, `deleted_user`
  - `pmpro_after_change_membership_level`
  - `added_user_meta` / `updated_user_meta` / `deleted_user_meta` for `first_name`, `last_name`, `pmpromd_hide_directory`, `pmpromd_pin_location` (filterable)
- Filters:
  - `pmpro_member_directory_cache_enabled` (bool, default `true`)
  - `pmpro_member_directory_cache_ttl` (seconds, default `15 * MINUTE_IN_SECONDS`)
  - `pmpro_member_directory_watched_user_meta` (array of meta keys)

The cache key embeds the SQL string verbatim, so anything that hooks `pmpro_member_directory_sql_parts` or `pmpro_member_directory_sql` (custom WHERE clauses, per-role visibility, etc.) automatically gets its own cache bucket — no separate cache logic needed for custom filters.

## Compatibility notes

- Uses `wp_cache_*` rather than transients, so a persistent object cache (Redis, Memcached) makes this cross-request; without one it degrades to per-request memoization, still useful when one request renders the shortcode multiple times (e.g. a sitemap pass).
- Version counter is stored in a **non-autoloaded** \`wp_options\` row so it survives a `wp_cache_flush()` and doesn't bloat the autoload weight.
- `wp_cache_get( 'cache_version', ... )` defaults `false` on miss → the function rehydrates from the option. Re-entrant safe.
- No backward-incompat changes to filters or rendered output. The existing `pmpromd_user_directory_results` filter still runs on every render (cache hit or miss) so downstream filtering remains consistent.

## Test plan

- [x] Cold render hits the DB (2 directory-SQL queries: \`SELECT\` users + \`COUNT\`)
- [x] Subsequent renders skip both queries (0 directory-SQL queries) and return identical output
- [x] \`user_register\` action invalidates → next render is cold again
- [x] Updating a watched meta key (\`first_name\`) invalidates
- [x] Updating an unwatched meta key does **not** invalidate
- [x] \`add_filter( 'pmpro_member_directory_cache_enabled', '__return_false' )\` bypasses cache entirely
- [x] Cache keys land in Redis when an object-cache drop-in is active; TTL ≈ 15m as configured

Verified locally on a flintdev site with PMPro 3.7.2, WP 6.9.4, PHP 8.3, and the Redis Object Cache drop-in. On a small 55-member dataset, warm renders run ~2.6× faster than cold; the speedup will be much larger on directories with thousands of members where the JOINs scan more rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)